### PR TITLE
Update logging around graphql

### DIFF
--- a/genotypes_processing.py
+++ b/genotypes_processing.py
@@ -103,8 +103,9 @@ def get_bone_marrow_sequencing_groups():
     }
     """
     )
-
+    logging.getLogger().setLevel(logging.WARN)
     sequencing_groups = query(_query)['project']['sequencingGroups']
+    logging.getLogger().setLevel(logging.INFO)
 
     bm_sequencing_groups = []
     for sg in sequencing_groups:


### PR DESCRIPTION
With logging.info as the level, the GraphQL library logs SO MUCH, it makes the Hail Batch pages slow to load. This silences that output for the duration of the query, then changes it back