### PR TITLE
extract sex info for tob and bioheart

### DIFF
--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -54,7 +54,7 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
     tob_meta = tob_meta[tob_meta['sex_karyotype'].isin(["XX", "XY"])]
     # encode sex as 1,2 instead
     tob_meta['sex'] = tob_meta['sex_karyotype'].replace('XY', '1')
-    tob_meta['sex'] = tob_meta['sex_karyotype'].replace('XX', '2')
+    tob_meta['sex'] = tob_meta['sex'].replace('XX', '2')
     # rename s as sample id to match bioheart file
     tob_meta['sample_id'] = tob_meta['s']
     tob_sex = tob_meta.loc[:, ["sample_id", "sex"]]

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -22,6 +22,9 @@ analysis-runner \
     python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-tob-wgs-test-analysis/joint-calling/v7/meta.tsv' \
                 --bioheart-sex-file-path 'gs://cpg-bioheart-test-analysis/hoptan-str/somalier/somalier.samples.tsv'
 
+main files:
+'gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv'
+'gs://cpg-bioheart-main-analysis/hoptan-str/somalier/somalier.samples.tsv
 """
 
 # from cpg_utils import to_path
@@ -47,6 +50,7 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
         ~tob_meta['s'].isin(["NA12878", "NA12891", "NA12892", "syndip"])
     ]
     # remove spaces from sex karyotypes
+    print(tob_meta['sex_karyotype'].unique())
     tob_meta['sex_karyotype'] = [
         sk.replace(" ", "") for sk in tob_meta['sex_karyotype']
     ]

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -24,7 +24,7 @@ analysis-runner \
 
 main files:
 'gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv'
-'gs://cpg-bioheart-main-analysis/hoptan-str/somalier/somalier.samples.tsv
+'gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv
 """
 
 # from cpg_utils import to_path
@@ -49,11 +49,7 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
     tob_meta = tob_meta[
         ~tob_meta['s'].isin(["NA12878", "NA12891", "NA12892", "syndip"])
     ]
-    # remove spaces from sex karyotypes
     print(tob_meta['sex_karyotype'].unique())
-    tob_meta['sex_karyotype'] = [
-        sk.replace(" ", "") for sk in tob_meta['sex_karyotype']
-    ]
     # remove samples with ambiguous sex inference
     tob_meta = tob_meta[tob_meta['sex_karyotype'].isin(["XX", "XY"])]
     # encode sex as 1,2 instead
@@ -65,6 +61,7 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
     # BioHEART sex info from Hope's Somalier stand alone run
     bioheart_meta = pd.read_csv(bioheart_sex_file_path, sep="\t")
     bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]
+    print(bioheart_sex['sex'].unique())
     # combine_info
     combined_sex = pd.concat([tob_sex, bioheart_sex], axis=0)
     sex_out_file = output_path('sex_tob_bioheart.csv')

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+"""
+This script will
+
+- extract sex information
+- extract age information
+
+for the TOB and BioHEART cohorts as part of TenK10K part1
+
+these will be used in the gene expression input preparation
+building inputs for the SAIGE-QTL association pipeline.
+
+
+To run:
+
+analysis-runner \
+    --description "get sample covariates" \
+    --dataset "bioheart" \
+    --access-level "test" \
+    --output-dir "saige-qtl/input_files/covariates/" \
+    python3 get_sample_covariates.py
+
+"""
+
+from cpg_utils import to_path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import dataset_path, get_batch, init_batch, output_path
+
+import click
+import pandas as pd
+
+
+@click.option(
+    '--tob-sex-file-path',
+    default='gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv',
+)
+@click.option(
+    '--bioheart-sex-file-path',
+    default='gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv',
+)
+@click.command()
+def main(tob_sex_file_path, bioheart_sex_file_path):
+    """
+    Get sex and age info for TOB and BioHEART individuals
+    """
+    # TOB sex info from Vlad's metadata file
+    tob_meta = pd.read_csv(tob_sex_file_path, sep="\t")
+    # remove non-TOB samples
+    tob_meta = tob_meta[
+        ~tob_meta['s'].isin(["NA12878", "NA12891", "NA12892", "syndip"])
+    ]
+    # remove samples with ambiguous sex inference
+    tob_meta = tob_meta[tob_meta['sex_karyotype'].isin(["XX", "XY"])]
+    # encode sex as 1,2 instead
+    tob_meta['sex'] = tob_meta['sex_karyotype'].replace('XY', '1')
+    tob_meta['sex'] = tob_meta['sex_karyotype'].replace('XX', '2')
+    # rename s as sample id to match bioheart file
+    tob_meta['sample_id'] = tob_meta['s']
+    tob_sex = tob_meta.loc[:, ["sample_id", "sex"]]
+    # BioHEART sex info from Hope's Somalier stand alone run
+    bioheart_meta = pd.read_csv(bioheart_sex_file_path, sep="\t")
+    bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]
+    # combine_info
+    combined_sex = pd.concat([tob_sex, bioheart_sex], axis=0)
+    sex_out_file = output_path('sex_tob_bioheart.csv')
+    combined_sex.to_csv(sex_out_file)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -27,9 +27,6 @@ main files:
 'gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv
 """
 
-# from cpg_utils import to_path
-# from cpg_utils.config import get_config
-# from cpg_utils.hail_batch import dataset_path, get_batch, init_batch, output_path
 from cpg_utils.hail_batch import output_path
 
 import click

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -19,7 +19,8 @@ analysis-runner \
     --dataset "bioheart" \
     --access-level "test" \
     --output-dir "saige-qtl/input_files/covariates/" \
-    python3 get_sample_covariates.py
+    python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv' \
+                --bioheart-sex-file-path 'gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv'
 
 """
 
@@ -32,14 +33,8 @@ import click
 import pandas as pd
 
 
-@click.option(
-    '--tob-sex-file-path',
-    default='gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv',
-)
-@click.option(
-    '--bioheart-sex-file-path',
-    default='gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv',
-)
+@click.option('--tob-sex-file-path')
+@click.option('--bioheart-sex-file-path')
 @click.command()
 def main(tob_sex_file_path, bioheart_sex_file_path):
     """

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -19,8 +19,8 @@ analysis-runner \
     --dataset "bioheart" \
     --access-level "test" \
     --output-dir "saige-qtl/input_files/covariates/" \
-    python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv' \
-                --bioheart-sex-file-path 'gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv'
+    python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-tob-wgs-test-analysis/joint-calling/v7/meta.tsv' \
+                --bioheart-sex-file-path 'gs://cpg-bioheart-test-analysis/hoptan-str/somalier/somalier.samples.tsv'
 
 """
 
@@ -45,6 +45,10 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
     # remove non-TOB samples
     tob_meta = tob_meta[
         ~tob_meta['s'].isin(["NA12878", "NA12891", "NA12892", "syndip"])
+    ]
+    # remove spaces from sex karyotypes
+    tob_meta['sex_karyotype'] = [
+        sk.replace(" ", "") for sk in tob_meta['sex_karyotype']
     ]
     # remove samples with ambiguous sex inference
     tob_meta = tob_meta[tob_meta['sex_karyotype'].isin(["XX", "XY"])]

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -49,7 +49,6 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
     tob_meta = tob_meta[
         ~tob_meta['s'].isin(["NA12878", "NA12891", "NA12892", "syndip"])
     ]
-    print(tob_meta['sex_karyotype'].unique())
     # remove samples with ambiguous sex inference
     tob_meta = tob_meta[tob_meta['sex_karyotype'].isin(["XX", "XY"])]
     # encode sex as 1,2 instead
@@ -58,11 +57,9 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
     # rename s as sample id to match bioheart file
     tob_meta['sample_id'] = tob_meta['s']
     tob_sex = tob_meta.loc[:, ["sample_id", "sex"]]
-    print(tob_sex['sex'].unique())
     # BioHEART sex info from Hope's Somalier stand alone run
     bioheart_meta = pd.read_csv(bioheart_sex_file_path, sep="\t")
     bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]
-    print(bioheart_sex['sex'].unique())
     # combine_info
     combined_sex = pd.concat([tob_sex, bioheart_sex], axis=0)
     sex_out_file = output_path('sex_tob_bioheart.csv')

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -23,9 +23,10 @@ analysis-runner \
 
 """
 
-from cpg_utils import to_path
-from cpg_utils.config import get_config
-from cpg_utils.hail_batch import dataset_path, get_batch, init_batch, output_path
+# from cpg_utils import to_path
+# from cpg_utils.config import get_config
+# from cpg_utils.hail_batch import dataset_path, get_batch, init_batch, output_path
+from cpg_utils.hail_batch import output_path
 
 import click
 import pandas as pd

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -58,6 +58,7 @@ def main(tob_sex_file_path, bioheart_sex_file_path):
     # rename s as sample id to match bioheart file
     tob_meta['sample_id'] = tob_meta['s']
     tob_sex = tob_meta.loc[:, ["sample_id", "sex"]]
+    print(tob_sex['sex'].unique())
     # BioHEART sex info from Hope's Somalier stand alone run
     bioheart_meta = pd.read_csv(bioheart_sex_file_path, sep="\t")
     bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]


### PR DESCRIPTION
First part of sample metadata extraction for TOB and BioHEART, starting with sex.

Successfully ran in test: https://batch.hail.populationgenomics.org.au/batches/432785/jobs/1

Made this file: https://console.cloud.google.com/storage/browser/_details/cpg-bioheart-test/saige-qtl/input_files/covariates/sex_tob_bioheart.csv;tab=live_object?authuser=0

I will include age also once that's in metamist, slack thread: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1707103307460719

As I mention in the slack, this script is a bit of a temporary way of extracting this info for these cohorts, while we await the sex inference to be fully part of the large cohort pipeline (SampleQC), and so accessible in other ways.

Sex and age are used as covariates in the association pipeline, so are needed to run SAIGE-QTL.