### PR TITLE
Add age to sample covariate script

### DIFF
--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -113,16 +113,16 @@ def main(
             try:
                 age = sg['sample']['participant']['meta']['age']
             except KeyError as e:
-                print(f"Key Error: - no {e} availabe for {cpg_id}")
+                print(f"Key Error: - no {e} available for {cpg_id}")
                 age = 'NA'
             age_dict_list.append({'sample_id': cpg_id, 'age': age})
     age_df = pd.DataFrame(age_dict_list)
 
     # index with sample id
     sex_df.index = sex_df['sample_id']
-    sex_df.drop(['sample_id'], axis=1)
+    sex_df.drop(['sample_id'], axis=1, inplace=True)
     age_df.index = age_df['sample_id']
-    age_df.drop(['sample_id'], axis=1)
+    age_df.drop(['sample_id'], axis=1, inplace=True)
     # combine sex and age info
     combined_sex_age = pd.concat([sex_df, age_df], axis=1)
     sex_age_out_file = output_path('sex_age_tob_bioheart.csv')

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -110,9 +110,10 @@ def main(
             try:
                 age = sg['sample']['participant']['meta']['age']
             except KeyError as e:
-                print(e)
+                print(f"Key Error: - {e}")
                 age = 'NA'
             age_dict[cpg_id] = age
+    print(age_dict)
     age_df = pd.DataFrame(age_dict)
     print(age_df.head())
 

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -37,7 +37,7 @@ from metamist.graphql import gql, query
 
 GET_PARTICIPANT_META_QUERY = gql(
     """
-    query GetMeta(project_name: String! ) {
+    query GetMeta($project_name: String! ) {
         project(name: $project_name) {
             participants {
                 meta

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -100,7 +100,8 @@ def main(
     # sex_out_file = output_path('sex_tob_bioheart.csv')
     # combined_sex.to_csv(sex_out_file)
     # age
-    age_dict: dict = {}
+    age_dict_list: list(dict) = []
+    # age_dict: dict = {}
     for project_name in project_names.split(','):
         query_vars = {'project_name': project_name}
         meta = query(GET_PARTICIPANT_META_QUERY, variables=query_vars)
@@ -113,11 +114,13 @@ def main(
                 print(f"Key Error: - {e}")
                 print(cpg_id)
                 age = 'NA'
-            age_dict[cpg_id] = age
-    print(age_dict)
-    age_df = pd.DataFrame.from_dict(
-        data=age_dict, orient='index', columns=['CPG_ID', 'age']
-    )
+            # age_dict[cpg_id] = age
+            age_dict_list.append({'id': cpg_id, 'age': age})
+    # print(age_dict)
+    # age_df = pd.DataFrame.from_dict(
+    #     data=age_dict, orient='index', columns=['age']
+    # )
+    age_df = pd.DataFrame(age_dict_list)
     print(age_df.head())
 
 

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -107,6 +107,7 @@ def main(
         print(meta)
         for sg in meta['project']['sequencingGroups']:
             cpg_id = sg['id']
+            print(sg)
             age = sg['sample']['participant']['meta']['age']
             age_dict[cpg_id] = age
     age_df = pd.DataFrame(age_dict)

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -105,7 +105,7 @@ def main(
         query_vars = {'project_name': project_name}
         meta = query(GET_PARTICIPANT_META_QUERY, variables=query_vars)
         print(meta)
-        for sg in meta['project'][0]['sequencingGroups']:
+        for sg in meta['project']['sequencingGroups']:
             cpg_id = sg['id']
             age = sg['sample']['participant']['meta']['age']
             age_dict[cpg_id] = age

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -99,6 +99,7 @@ def main(
     # combine_info
     sex_df = pd.concat([tob_sex, bioheart_sex], axis=0)
     print(sex_df.shape)
+    print(sex_df.head())
     # sex_out_file = output_path('sex_tob_bioheart.csv')
     # sex_df.to_csv(sex_out_file)
 
@@ -115,16 +116,22 @@ def main(
             try:
                 age = sg['sample']['participant']['meta']['age']
             except KeyError as e:
-                print(f"Key Error: - no {e} availabe foe {cpg_id}")
+                # print(f"Key Error: - no {e} availabe for {cpg_id}")
                 age = 'NA'
             age_dict_list.append({'sample_id': cpg_id, 'age': age})
     age_df = pd.DataFrame(age_dict_list)
     print(age_df.shape)
+    print(age_df.head())
     # age_out_file = output_path('age_tob_bioheart.csv')
     # age_df.to_csv(age_out_file)
 
+    # index with sample id
+    sex_df.index = sex_df['sample_id']
+    age_df.index = age_df['sample_id']
     # combine sex and age info
     combined_sex_age = pd.concat([sex_df, age_df], axis=1)
+    print(combined_sex_age.shape)
+    print(combined_sex_age.head())
     sex_age_out_file = output_path('sex_age_tob_bioheart.csv')
     combined_sex_age.to_csv(sex_age_out_file)
 

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -120,9 +120,9 @@ def main(
 
     # index with sample id
     sex_df.index = sex_df['sample_id']
-    sex_df.drop(['sample_id'])
+    sex_df.drop(['sample_id'], axis=1)
     age_df.index = age_df['sample_id']
-    age_df.drop(['sample_id'])
+    age_df.drop(['sample_id'], axis=1)
     # combine sex and age info
     combined_sex_age = pd.concat([sex_df, age_df], axis=1)
     sex_age_out_file = output_path('sex_age_tob_bioheart.csv')

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -100,10 +100,17 @@ def main(
     # sex_out_file = output_path('sex_tob_bioheart.csv')
     # combined_sex.to_csv(sex_out_file)
     # age
+    age_dict: dict = {}
     for project_name in project_names.split(','):
         query_vars = {'project_name': project_name}
         meta = query(GET_PARTICIPANT_META_QUERY, variables=query_vars)
         print(meta)
+        for sg in meta['project'][0]['sequencingGroups']:
+            cpg_id = sg['id']
+            age = sg['sample']['participant']['meta']['age']
+            age_dict[cpg_id] = age
+    age_df = pd.DataFrame(age_dict)
+    print(age_df.head())
 
 
 if __name__ == '__main__':

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -111,10 +111,11 @@ def main(
                 age = sg['sample']['participant']['meta']['age']
             except KeyError as e:
                 print(f"Key Error: - {e}")
+                print(cpg_id)
                 age = 'NA'
             age_dict[cpg_id] = age
     print(age_dict)
-    age_df = pd.DataFrame(age_dict)
+    age_df = pd.DataFrame(age_dict, columns=['CPG_ID','age'])
     print(age_df.head())
 
 

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -30,51 +30,73 @@ main files:
 from cpg_utils.hail_batch import output_path
 
 import click
-import sys
+# import sys
 import pandas as pd
 
+from metamist.graphql import gql, query
 
-@click.option(
-    '--tob-sex-file-path',
-    help='this file should contain sample id and inferred sex info for the tob cohort',
+GET_PARTICIPANT_META_QUERY = gql(
+    """
+    query GetMeta(project_name: String! ) {
+        project(name: $project_name) {
+            participants {
+                meta
+            }
+        }
+    }
+    """
 )
-@click.option(
-    '--bioheart-sex-file-path',
-    help='this file should contain sample id and inferred sex info for the bioheart cohort',
-)
+
+# @click.option(
+#     '--tob-sex-file-path',
+#     help='this file should contain sample id and inferred sex info for the tob cohort',
+# )
+# @click.option(
+#     '--bioheart-sex-file-path',
+#     help='this file should contain sample id and inferred sex info for the bioheart cohort',
+# )
+@click.option('--project-names', default='tob-wgs,bioheart')
 @click.command()
-def main(tob_sex_file_path, bioheart_sex_file_path):
+def main(
+    # tob_sex_file_path,
+    # bioheart_sex_file_path,
+    project_names):
     """
     Get sex and age info for TOB and BioHEART individuals
     """
-    # check if files exist
-    try:
-        # TOB sex info from Vlad's metadata file
-        tob_meta = pd.read_csv(tob_sex_file_path, sep="\t")
-        # BioHEART sex info from Hope's Somalier stand alone run
-        bioheart_meta = pd.read_csv(bioheart_sex_file_path, sep="\t")
-    except FileNotFoundError as e:
-        print(f"Error: File not found - {e}")
-        sys.exit(1)
-    # extract sex for TOB
-    # remove non-TOB samples
-    tob_meta = tob_meta[
-        ~tob_meta['s'].isin(["NA12878", "NA12891", "NA12892", "syndip"])
-    ]
-    # remove samples with ambiguous sex inference
-    tob_meta = tob_meta[tob_meta['sex_karyotype'].isin(["XX", "XY"])]
-    # encode sex as 1,2 instead
-    tob_meta['sex'] = tob_meta['sex_karyotype'].replace('XY', '1')
-    tob_meta['sex'] = tob_meta['sex'].replace('XX', '2')
-    # rename s as sample id to match bioheart file
-    tob_meta['sample_id'] = tob_meta['s']
-    tob_sex = tob_meta.loc[:, ["sample_id", "sex"]]
-    # extract sex for BioHEART
-    bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]
-    # combine_info
-    combined_sex = pd.concat([tob_sex, bioheart_sex], axis=0)
-    sex_out_file = output_path('sex_tob_bioheart.csv')
-    combined_sex.to_csv(sex_out_file)
+    # # check if files exist
+    # try:
+    #     # TOB sex info from Vlad's metadata file
+    #     tob_meta = pd.read_csv(tob_sex_file_path, sep="\t")
+    #     # BioHEART sex info from Hope's Somalier stand alone run
+    #     bioheart_meta = pd.read_csv(bioheart_sex_file_path, sep="\t")
+    # except FileNotFoundError as e:
+    #     print(f"Error: File not found - {e}")
+    #     sys.exit(1)
+    # # extract sex for TOB
+    # # remove non-TOB samples
+    # tob_meta = tob_meta[
+    #     ~tob_meta['s'].isin(["NA12878", "NA12891", "NA12892", "syndip"])
+    # ]
+    # # remove samples with ambiguous sex inference
+    # tob_meta = tob_meta[tob_meta['sex_karyotype'].isin(["XX", "XY"])]
+    # # encode sex as 1,2 instead
+    # tob_meta['sex'] = tob_meta['sex_karyotype'].replace('XY', '1')
+    # tob_meta['sex'] = tob_meta['sex'].replace('XX', '2')
+    # # rename s as sample id to match bioheart file
+    # tob_meta['sample_id'] = tob_meta['s']
+    # tob_sex = tob_meta.loc[:, ["sample_id", "sex"]]
+    # # extract sex for BioHEART
+    # bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]
+    # # combine_info
+    # combined_sex = pd.concat([tob_sex, bioheart_sex], axis=0)
+    # sex_out_file = output_path('sex_tob_bioheart.csv')
+    # combined_sex.to_csv(sex_out_file)
+    # age
+    for project_name in project_names.split(','):
+        query_vars = {'project_name':project_name}
+        meta = query(GET_PARTICIPANT_META_QUERY, variables=query_vars)
+        print(meta)
 
 
 if __name__ == '__main__':

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -107,8 +107,11 @@ def main(
         print(meta)
         for sg in meta['project']['sequencingGroups']:
             cpg_id = sg['id']
-            print(sg)
-            age = sg['sample']['participant']['meta']['age']
+            try:
+                age = sg['sample']['participant']['meta']['age']
+            except KeyError as e:
+                print(e)
+                age = 'NA'
             age_dict[cpg_id] = age
     age_df = pd.DataFrame(age_dict)
     print(age_df.head())

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -27,9 +27,10 @@ main files:
 'gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv
 """
 
-from cpg_utils.hail_batch import output_path
+# from cpg_utils.hail_batch import output_path
 
 import click
+
 # import sys
 import pandas as pd
 
@@ -39,8 +40,13 @@ GET_PARTICIPANT_META_QUERY = gql(
     """
     query GetMeta($project_name: String! ) {
         project(name: $project_name) {
-            participants {
-                meta
+            sequencingGroups {
+                id
+                sample {
+                    participant {
+                        meta
+                    }
+                }
             }
         }
     }
@@ -60,7 +66,8 @@ GET_PARTICIPANT_META_QUERY = gql(
 def main(
     # tob_sex_file_path,
     # bioheart_sex_file_path,
-    project_names):
+    project_names,
+):
     """
     Get sex and age info for TOB and BioHEART individuals
     """
@@ -94,7 +101,7 @@ def main(
     # combined_sex.to_csv(sex_out_file)
     # age
     for project_name in project_names.split(','):
-        query_vars = {'project_name':project_name}
+        query_vars = {'project_name': project_name}
         meta = query(GET_PARTICIPANT_META_QUERY, variables=query_vars)
         print(meta)
 

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -115,7 +115,9 @@ def main(
                 age = 'NA'
             age_dict[cpg_id] = age
     print(age_dict)
-    age_df = pd.DataFrame(age_dict, columns=['CPG_ID','age'])
+    age_df = pd.DataFrame.from_dict(
+        data=age_dict, orient='index', columns=['CPG_ID', 'age']
+    )
     print(age_df.head())
 
 

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -20,7 +20,8 @@ analysis-runner \
     --access-level "test" \
     --output-dir "saige-qtl/input_files/covariates/" \
     python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-tob-wgs-test-analysis/joint-calling/v7/meta.tsv' \
-                --bioheart-sex-file-path 'gs://cpg-bioheart-test-analysis/hoptan-str/somalier/somalier.samples.tsv'
+                --bioheart-sex-file-path 'gs://cpg-bioheart-test-analysis/hoptan-str/somalier/somalier.samples.tsv' \
+                --project-names 'tob-wgs-test,bioheart-test'
 
 main files:
 'gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv'
@@ -98,8 +99,8 @@ def main(
     bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]
     # combine_info
     sex_df = pd.concat([tob_sex, bioheart_sex], axis=0)
-    print(sex_df.shape)
-    print(sex_df.head())
+    # print(sex_df.shape)
+    # print(sex_df.head())
     # sex_out_file = output_path('sex_tob_bioheart.csv')
     # sex_df.to_csv(sex_out_file)
 
@@ -116,12 +117,12 @@ def main(
             try:
                 age = sg['sample']['participant']['meta']['age']
             except KeyError as e:
-                # print(f"Key Error: - no {e} availabe for {cpg_id}")
+                print(f"Key Error: - no {e} availabe for {cpg_id}")
                 age = 'NA'
             age_dict_list.append({'sample_id': cpg_id, 'age': age})
     age_df = pd.DataFrame(age_dict_list)
-    print(age_df.shape)
-    print(age_df.head())
+    # print(age_df.shape)
+    # print(age_df.head())
     # age_out_file = output_path('age_tob_bioheart.csv')
     # age_df.to_csv(age_out_file)
 

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -21,7 +21,7 @@ analysis-runner \
     --output-dir "saige-qtl/input_files/covariates/" \
     python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-tob-wgs-test-analysis/joint-calling/v7/meta.tsv' \
                 --bioheart-sex-file-path 'gs://cpg-bioheart-test-analysis/hoptan-str/somalier/somalier.samples.tsv' \
-                --project-names 'tob-wgs-test,bioheart-test'
+                --project-names 'tob-wgs,bioheart'
 
 main files:
 'gs://cpg-tob-wgs-main-analysis/joint-calling/v7/meta.tsv'
@@ -99,10 +99,6 @@ def main(
     bioheart_sex = bioheart_meta.loc[:, ["sample_id", "sex"]]
     # combine_info
     sex_df = pd.concat([tob_sex, bioheart_sex], axis=0)
-    # print(sex_df.shape)
-    # print(sex_df.head())
-    # sex_out_file = output_path('sex_tob_bioheart.csv')
-    # sex_df.to_csv(sex_out_file)
 
     # age
     # create a list from dictionary to populate
@@ -121,18 +117,14 @@ def main(
                 age = 'NA'
             age_dict_list.append({'sample_id': cpg_id, 'age': age})
     age_df = pd.DataFrame(age_dict_list)
-    # print(age_df.shape)
-    # print(age_df.head())
-    # age_out_file = output_path('age_tob_bioheart.csv')
-    # age_df.to_csv(age_out_file)
 
     # index with sample id
     sex_df.index = sex_df['sample_id']
+    sex_df.drop(['sample_id'])
     age_df.index = age_df['sample_id']
+    age_df.drop(['sample_id'])
     # combine sex and age info
     combined_sex_age = pd.concat([sex_df, age_df], axis=1)
-    print(combined_sex_age.shape)
-    print(combined_sex_age.head())
     sex_age_out_file = output_path('sex_age_tob_bioheart.csv')
     combined_sex_age.to_csv(sex_age_out_file)
 


### PR DESCRIPTION
Add age to this script which was already extracting (inferred) sex info for TenK10K phase individuals (aka TOB + BioHEART).

Ran successfully in test: https://batch.hail.populationgenomics.org.au/batches/432922/jobs/1

Generating this output file: https://console.cloud.google.com/storage/browser/_details/cpg-bioheart-test/saige-qtl/input_files/covariates/sex_age_tob_bioheart.csv;tab=live_object?authuser=0

(we don't have sex and age for the same individuals, but that may have to do with the specific sets of samples included in the various files, vs metamist)