### PR TITLE
maybe this?

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -63,7 +63,7 @@ def replace_loci_with_structs(mt: hl.MatrixTable) -> hl.MatrixTable:
     mt = mt.annotate_rows(
         new_locus=hl.struct(
             contig=hl.int(mt.locus.contig.replace('chr', '')),
-            position=mt.locus.position
+            position=mt.locus.position,
         )
     )
     # swap the new and old IDs


### PR DESCRIPTION
The [export_plink docs](https://hail.is/docs/0.2/methods/impex.html#hail.methods.export_plink) say that it accepts a `Locus`, or any `Struct` that implements a contig + position. This change (untested) takes the MT, creates a new version of `locus` without the `chr` prefix, uses that as a key, then export_plink is called. 

Not sure if a similar trick is possible with a VCF export - I doubt it, that would mean a VCF is written where the 'contigs' in the variant rows don't match anything in the headers
