### PR TITLE
Incorporate checkpoints, reduce counting

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -53,8 +53,8 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
         return mt.checkpoint(checkpoint_path, overwrite=True)
 
     if (
-            to_path(checkpoint_path).exists() and
-            (to_path(checkpoint_path) / '_SUCCESS').exists()
+        to_path(checkpoint_path).exists()
+        and (to_path(checkpoint_path) / '_SUCCESS').exists()
     ):
         return hl.read_matrix_table(checkpoint_path)
     else:
@@ -215,7 +215,9 @@ def main(
         vre_mt = mt.filter_rows(mt.variant_qc.AC[1] > vre_mac_threshold)
 
         # set a checkpoint, and either re-use or write
-        post_common_checkpoint = output_path('common_reduced_checkpoint.mt', category='tmp')
+        post_common_checkpoint = output_path(
+            'common_reduced_checkpoint.mt', category='tmp'
+        )
         vre_mt = checkpoint_mt(vre_mt, post_common_checkpoint)
 
         if (n_ac_vars := vre_mt.count_rows()) == 0:

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -75,7 +75,9 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
     else:
         raise FileNotFoundError('Checkpoint exists but is incomplete, was not forced')
 
-    logging.info(f'Dimensions of MT: {mt.count()}, across {mt.n_partitions()} partitions')
+    logging.info(
+        f'Dimensions of MT: {mt.count()}, across {mt.n_partitions()} partitions'
+    )
     return mt
 
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -245,8 +245,7 @@ def main(
         vre_mt = checkpoint_mt(vre_mt, post_common_checkpoint)
 
         if (n_ac_vars := vre_mt.count_rows()) == 0:
-            logging.info('No variants left, exiting!')
-            return  # todo fail instead?
+            raise ValueError('No variants left, exiting!')
         logging.info(f'MT filtered to common enough variants, {n_ac_vars} left')
 
         # since pruning is very costly, subset first a bit

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -228,7 +228,7 @@ def main(
         # since pruning is very costly, subset first a bit
         random.seed(0)
         # vre_mt = vre_mt.sample_rows(p=0.01)
-        logging.info('subset completed')  # ? no checkpointing done?
+        logging.info('subset completed')  # ? no subsetting done?
 
         # perform LD pruning
         pruned_variant_table = hl.ld_prune(vre_mt.GT, r2=0.2, bp_window_size=500000)


### PR DESCRIPTION
There are still so many instances of `mt.count()` here - you're tripling the amount of computation hail needs to do just for a couple of logging statements. Please stop using count unless it's immediately after a read or checkpoint 😭 

It's worth noting that when creating a checkpoint Hail will post a message into the logging saying the number of rows, columns, and partitions which were written.

---
Matt was wrong about the stuff down here, so I've re-written this section

In the Plink block you're using [split_multi](https://github.com/populationgenomics/saige-tenk10k/blob/main/get_genotype_vcf.py#L177) - you're then also explicitly removing those split variants [here](https://github.com/populationgenomics/saige-tenk10k/blob/main/get_genotype_vcf.py#L181). Can this be replaced with removing multiallelic variants prior to densification?

