### PR TITLE
Adds arguments from config

### DIFF
--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -12,7 +12,7 @@ cis_window_size = 100000
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
 [saige.build_fit_null]
-covarColList = 'sex,age,harmony_PC1,total_counts,sequencing_library'
+covarColList = 'sex,age,harmony_PC1,total_counts
 sampleCovarColList = 'sex,age'
 sampleIDColinphenoFile = 'individual'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -6,19 +6,15 @@ vds_version = 'vds1-0'
 
 # secondary arguments
 
-# these two aren't really lists...
-covs = 'sex,age,harmony_PC1,total_counts,sequencing_library'
-sample_covs = 'sex,age'
-
-sample_id = 'individual'
 max_parallel_jobs = 100
 cis_window_size = 100000
-skip_vre = false
-is_cov_transform = true
 
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
 [saige.build_fit_null]
+covarColList = 'sex,age,harmony_PC1,total_counts,sequencing_library'
+sampleCovarColList = 'sex,age'
+sampleIDColinphenoFile = 'individual'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal
 traitType = 'count'
 # option to skip Variance Ratio estimation (discouraged)

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -12,7 +12,7 @@ cis_window_size = 100000
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
 [saige.build_fit_null]
-covarColList = 'sex,age,harmony_PC1,total_counts
+covarColList = 'sex,age,harmony_PC1,total_counts'
 sampleCovarColList = 'sex,age'
 sampleIDColinphenoFile = 'individual'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -1,6 +1,6 @@
 [saige]
 # principal arguments
-celltypes = ['B_memory']
+celltypes = ['B_naive']
 chromosomes = ['chr21']
 vds_version = 'vds1-0'
 

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -5,8 +5,11 @@ chromosomes = ['chr1']
 vds_version = 'vds1-0'
 
 # secondary arguments
-covs = ['sex,age,harmony_PC1,total_counts,sequencing_library']
-sample_covs = ['sex,age']
+
+# these two aren't really lists...
+covs = 'sex,age,harmony_PC1,total_counts,sequencing_library'
+sample_covs = 'sex,age'
+
 sample_id = 'individual'
 max_parallel_jobs = 100
 cis_window_size = 100000

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -1,16 +1,43 @@
 [saige]
+# principal arguments
+celltypes = ['CD4_Naive']
+chromosomes = ['chr1']
+vds_version = 'vds1-0'
 
-# any settings to do with this workflow in general
+# secondary arguments
+covs = ['sex,age,harmony_PC1,total_counts,sequencing_library']
+sample_covs = ['sex,age']
+sample_id = 'individual'
+max_parallel_jobs = 100
+cis_window_size = 100000
+skip_vre = false
+is_cov_transform = true
+
+[saige.build_fit_null]
+# these args are applied directly to step1_fitNULLGLMM_qtl.R
+# as "--{key}={value} "
+traitType = 'count'
+skipVarianceRatioEstimation = 'FALSE'
+isRemoveZerosinPheno = 'FALSE'
+useSparseGRMtoFitNULL = 'FALSE'
+useGRMtoFitNULL = 'FALSE'
+isCovariateOffset = 'FALSE'
+isCovariateTransform = 'TRUE'
+skipModelFitting = 'FALSE'
+tol = 0.00001
+IsOverwriteVarianceRatioFile = 'TRUE'
+
+[saige.sv_test]
+vcf_field = 'GT'
+min_maf = 0
+min_mac = 5
+loco_bool = 'FALSE'
+n_markers = 10000
+spa_cutoff = 10000
 
 
 [saige.job_specs.fit_null]
 storage = "10Gi"
 memory = "10Gi"
 
-[saige.job_specs.run_sv_assoc]
-storage = "10Gi"
-memory = "10Gi"
 
-[saige.job_specs.gene_pvals]
-storage = "10Gi"
-memory = "10Gi"

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -1,7 +1,7 @@
 [saige]
 # principal arguments
-celltypes = ['B_naive']
-chromosomes = ['chr21']
+celltypes = ['CD4_TCM','CD4_Naive','NK','CD8_TEM','B_naive','CD8_Naive','CD14_Mono','CD4_TEM','CD8_TCM','B_intermediate','Treg','B_memory','CD4_CTL','gdT','MAIT','CD16_Mono','NK_CD56bright','cDC2','NK_Proliferating','dnT','pDC','Plasmablast','ILC','HSPC','CD8_Proliferating','CD4_Proliferating','cDC1','ASDC']
+chromosomes = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9','chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17','chr18','chr19','chr20','chr21','chr22']
 vds_version = 'vds1-0'
 
 # secondary arguments

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -31,12 +31,12 @@ tol = 0.00001
 IsOverwriteVarianceRatioFile = 'TRUE'
 
 [saige.sv_test]
-vcf_field = 'GT'
-min_maf = 0
-min_mac = 5
-loco_bool = 'FALSE'
-n_markers = 10000
-spa_cutoff = 10000
+vcfField = 'GT'
+minMAF = 0
+minMAC = 5
+LOCO = 'FALSE'
+markers_per_chunk = 10000
+SPAcutoff = 10000
 
 
 [saige.job_specs.fit_null]

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -32,8 +32,11 @@ IsOverwriteVarianceRatioFile = 'TRUE'
 
 [saige.sv_test]
 vcfField = 'GT'
+# minimum variant minor allele frequency to include
 minMAF = 0
+# minimum variant minor allele count to include
 minMAC = 5
+# leave one chromosome out
 LOCO = 'FALSE'
 markers_per_chunk = 10000
 SPAcutoff = 10000

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -1,7 +1,7 @@
 [saige]
 # principal arguments
-celltypes = ['CD4_Naive']
-chromosomes = ['chr1']
+celltypes = ['B_memory']
+chromosomes = ['chr21']
 vds_version = 'vds1-0'
 
 # secondary arguments

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -16,17 +16,23 @@ cis_window_size = 100000
 skip_vre = false
 is_cov_transform = true
 
-[saige.build_fit_null]
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
+[saige.build_fit_null]
+# Poisson, count_nb = Negative Binomial, quantitative = Normal
 traitType = 'count'
+# option to skip Variance Ratio estimation (discouraged)
 skipVarianceRatioEstimation = 'FALSE'
 isRemoveZerosinPheno = 'FALSE'
 useSparseGRMtoFitNULL = 'FALSE'
 useGRMtoFitNULL = 'FALSE'
+# option to add an offset to the fixed covariates (???)
 isCovariateOffset = 'FALSE'
+# option to transform (scale?) covariates?
 isCovariateTransform = 'TRUE'
+# option to skip model fitting (discouraged)
 skipModelFitting = 'FALSE'
+# tolerance for convergence
 tol = 0.00001
 IsOverwriteVarianceRatioFile = 'TRUE'
 

--- a/saige_assc.toml
+++ b/saige_assc.toml
@@ -38,9 +38,6 @@ LOCO = 'FALSE'
 markers_per_chunk = 10000
 SPAcutoff = 10000
 
-
 [saige.job_specs.fit_null]
 storage = "10Gi"
 memory = "10Gi"
-
-

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -21,7 +21,7 @@ analysis-runner \
     --description "SAIGE-QTL association pipeline" \
     --dataset "bioheart" \
     --access-level "test" \
-    --output-dir "saige-qtl/output_files/" \
+    --output-dir "saige-qtl/" \
      python3 saige_assoc.py
 
 """

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -51,12 +51,6 @@ def build_fit_null_command(pheno_file: str, output_prefix: str, plink_path: str,
     - output prefix: where to save the fitted model (.rda)
     - Plink path: path to plink file (subset of ~2,000 markers for VRE)
     - pheno col: name of column specifying pheno (default: "y")
-    - trait type: count = Poisson, count_nb = Negative Binomial, quantitative = Normal
-    - option to skip Variance Ratio estimation (discouraged)
-    - option to add an offset to the fixed covariates (???)
-    - option to transform (scale?) covariates?
-    - option to skip model fitting (discouraged)
-    - tolerance for convergence
     - overwrite variance ratio file (estimated here)
 
     Output:
@@ -101,9 +95,6 @@ def build_run_single_variant_test_command(
     - cis window: file with chrom | start | end to specify window
     - GMMAT model file: null model fit from previous step (.rda)
     - Variance Ratio file: as estimated from previous step (.txt)
-    - min MAF: minimum variant minor allele frequency to include
-    - min MAC: minimum variant minor allele count to include
-    - LOCO: leave one chromosome out
 
     Output:
     Rscript command (str) ready to run

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -213,7 +213,7 @@ def run_fit_null_job(
         Tuple: (Job | None, ResourceGroup)
 
     """
-    if to_path(null_output_path).exists():
+    if to_path(f'{null_output_path}.rda').exists():
         return None, get_batch().read_input_group(
             **{
                 'rda': f'{null_output_path}.rda',

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -39,7 +39,9 @@ from cpg_utils.hail_batch import dataset_path, get_batch, image_path, output_pat
 
 
 # Fit null model (step 1)
-def build_fit_null_command(pheno_file: str, output_prefix: str, plink_path: str, pheno_col: str):
+def build_fit_null_command(
+    pheno_file: str, output_prefix: str, plink_path: str, pheno_col: str
+):
     """Build SAIGE command for fitting null model
     This will fit a Poisson / NB mixed model under the null hypothesis
 
@@ -62,7 +64,12 @@ def build_fit_null_command(pheno_file: str, output_prefix: str, plink_path: str,
     )
 
     # pull all values from the config file's saige.build_fit_null section
-    args_from_config = ' '.join([f'--{key}={value}' for key, value in get_config()['saige']['build_fit_null'].items()])
+    args_from_config = ' '.join(
+        [
+            f'--{key}={value}'
+            for key, value in get_config()['saige']['build_fit_null'].items()
+        ]
+    )
 
     return f"""
         Rscript /usr/local/bin/step1_fitNULLGLMM_qtl.R \
@@ -81,7 +88,7 @@ def build_run_single_variant_test_command(
     chrom: str,
     cis_window_file: str,
     gmmat_model_path: str,
-    variance_ratio_path: str
+    variance_ratio_path: str,
 ):
     """
     Build SAIGE command for running single variant test
@@ -157,7 +164,7 @@ def build_obtain_gene_level_pvals_command(
         Rscript /usr/local/bin/step3_gene_pvalue_qtl.R \
         --assocFile={saige_sv_output_file} \
         --geneName={gene_name} \
-        --genePval_outputFile={saige_job.output} 
+        --genePval_outputFile={saige_job.output}
     """
     saige_job.image(image_path('saige-qtl'))
     saige_job.command(saige_command_step3)
@@ -349,7 +356,7 @@ def main(
                     output_path(f'output_files/{celltype}_{gene}'),
                     pheno_file=pheno_cov_path,
                     plink_path=vre_plink_path,
-                    pheno_col=gene
+                    pheno_col=gene,
                 )
                 if null_job:
                     manage_concurrency_for_job(null_job)

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=import-error,line-too-long,too-many-arguments
+# pylint: disable=import-error,line-too-long
 
 """
 Hail Batch workflow to perform association tests using SAIGE-QTL


### PR DESCRIPTION
Sources all possible arguments from config

For the R script builders, this directly connects the command-string builder to the config contents. This means that the name of the config entry doesn't map 1:1 with what you had before, e.g.

input: `sample_covs`
passed on: `sample_cov_col_list=sample_covs`
into Rscript: `--sampleCovarColList={sample_cov_col_list}`

This value is now just in the config as `sampleCovarColList`