### PR TITLE
add remove related individuals

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -241,6 +241,15 @@ def main(
             # densify to matrix table object
             mt = hl.vds.to_dense_mt(chrom_vds)
 
+            # filter out related samples
+            # this will get dropped as the vds file will already be clean
+            related_ht = hl.read_table(
+                'gs://cpg-bioheart-main-analysis/large_cohort/v1-0/relateds_to_drop.ht'
+            )
+            related_samples = related_ht.s.collect()
+            related_samples = hl.literal(related_samples)
+            mt = mt.filter_cols(~related_samples.contains(mt['s']))
+
             # filter out loci & variant QC
             mt = mt.filter_rows(hl.len(mt.alleles) == 2)  # remove hom-ref
             if exclude_multiallelic:  # biallelic only (exclude multiallelic)


### PR DESCRIPTION
The starting VDS used here in the future will be the output of the large cohort pipeline, which will be after sample and variant QC, so related individuals will have been removed before this pipeline starts.

However in the meantime, I am adding a manual removal of the related samples to drop, prior to building the genotype files.

Syntax tested in a notebook:

<img width="476" alt="Screen Shot 2024-03-11 at 3 19 30 pm" src="https://github.com/populationgenomics/saige-tenk10k/assets/25035866/cf09fc7b-9610-45ab-afaf-b77a7940c2e4">
