### PR TITLE
Read covariate file from analysis bucket, not main bucket 

### DIFF
--- a/get_anndata.py
+++ b/get_anndata.py
@@ -226,7 +226,7 @@ def main(
     # sample level covariates (age + sex + genotype PCs)
     # age from metamist, sex from somalier + Vlad's file for now
     sample_covs_file = dataset_path(
-        f'{sample_covs_files_prefix}/sex_age_geno_pcs_tob_bioheart.csv'
+        f'{sample_covs_files_prefix}/sex_age_geno_pcs_tob_bioheart.csv', 'analysis'
     )
 
     for celltype in celltypes.split(','):


### PR DESCRIPTION
FileNotFound error because covariate file is being written to `analysis` bucket (https://github.com/populationgenomics/saige-tenk10k/blob/4513ea0043749a5e43c5131d9d6b1c00e841c378/get_sample_covariates.py#L169), but this get_anndata.py script is expecting the file to be in main. 

Solution is to add `analysis` as a param when reading in the input file. 

