### PR TITLE
Drop rows with NA values in the sex,age,pc dataframe 

### DIFF
--- a/get_anndata.py
+++ b/get_anndata.py
@@ -144,7 +144,6 @@ def make_pheno_cov(
         sample_covs_cells_df['sex'] = sample_covs_cells_df['sex'].fillna(0)
     if fill_in_age:
         sample_covs_cells_df['age'] = sample_covs_cells_df['age'].fillna(mean_age)
-    if fill_in_sex is False or fill_in_age is False:
         # drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
         sample_covs_cells_df = sample_covs_cells_df.dropna()
     gene_adata = expression_adata[:, expression_adata.var['gene_name'] == gene]

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -144,6 +144,9 @@ def make_pheno_cov(
         sample_covs_cells_df['sex'] = sample_covs_cells_df['sex'].fillna(0)
     if fill_in_age:
         sample_covs_cells_df['age'] = sample_covs_cells_df['age'].fillna(mean_age)
+    if fill_in_sex is False or fill_in_age is False:
+        # drop rows with missing values (SAIGE throws an error:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
+        sample_covs_cells_df = sample_covs_cells_df.dropna()
     gene_adata = expression_adata[:, expression_adata.var['gene_name'] == gene]
     gene_name = gene.replace("-", "_")
     expr_df = pd.DataFrame(

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -145,7 +145,7 @@ def make_pheno_cov(
     if fill_in_age:
         sample_covs_cells_df['age'] = sample_covs_cells_df['age'].fillna(mean_age)
     if fill_in_sex is False or fill_in_age is False:
-        # drop rows with missing values (SAIGE throws an error:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
+        # drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
         sample_covs_cells_df = sample_covs_cells_df.dropna()
     gene_adata = expression_adata[:, expression_adata.var['gene_name'] == gene]
     gene_name = gene.replace("-", "_")

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -144,8 +144,8 @@ def make_pheno_cov(
         sample_covs_cells_df['sex'] = sample_covs_cells_df['sex'].fillna(0)
     if fill_in_age:
         sample_covs_cells_df['age'] = sample_covs_cells_df['age'].fillna(mean_age)
-# drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
-sample_covs_cells_df = sample_covs_cells_df.dropna()
+    # drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
+    sample_covs_cells_df = sample_covs_cells_df.dropna()
     gene_adata = expression_adata[:, expression_adata.var['gene_name'] == gene]
     gene_name = gene.replace("-", "_")
     expr_df = pd.DataFrame(

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -145,7 +145,7 @@ def make_pheno_cov(
     if fill_in_age:
         sample_covs_cells_df['age'] = sample_covs_cells_df['age'].fillna(mean_age)
 # drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
-        sample_covs_cells_df = sample_covs_cells_df.dropna()
+sample_covs_cells_df = sample_covs_cells_df.dropna()
     gene_adata = expression_adata[:, expression_adata.var['gene_name'] == gene]
     gene_name = gene.replace("-", "_")
     expr_df = pd.DataFrame(

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -144,7 +144,7 @@ def make_pheno_cov(
         sample_covs_cells_df['sex'] = sample_covs_cells_df['sex'].fillna(0)
     if fill_in_age:
         sample_covs_cells_df['age'] = sample_covs_cells_df['age'].fillna(mean_age)
-        # drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
+# drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
         sample_covs_cells_df = sample_covs_cells_df.dropna()
     gene_adata = expression_adata[:, expression_adata.var['gene_name'] == gene]
     gene_name = gene.replace("-", "_")


### PR DESCRIPTION
NA-containing rows seem to be problematic for SAIGE - https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91, so we specify if `fill_in_sex` or `fill_in_age` is False, ensure that rows with missing values are dropped prior to making the pheno_cov files. 