### PR TITLE
Replace VDS version param with VDS path for flexibility AND fix bug in re-partitioning of the MT checkpoints

### DIFF
--- a/get_anndata.py
+++ b/get_anndata.py
@@ -245,7 +245,6 @@ def main(
     )
 
     for celltype in celltypes.split(','):
-
         # extract cell-level covariates
         # expression PCs, cell type specific
         celltype_covs_file = dataset_path(

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -298,7 +298,7 @@ def main(
             add_remove_chr_and_index_job(rv_vcf_path)
 
     # subset variants for variance ratio estimation
-    vre_plink_path = output_path(f'vds-{vds_name}/vre_plink_2000_variants', 'analysis')
+    vre_plink_path = output_path(f'vds-{vds_name}/vre_plink_2000_variants')
     vre_bim_path = f'{vre_plink_path}.bim'
     plink_existence_outcome = can_reuse(vre_bim_path)
     logging.info(f'Does {vre_bim_path} exist? {plink_existence_outcome}')

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -223,9 +223,7 @@ def main(
         cv_vcf_existence_outcome = can_reuse(cv_vcf_path)
         logging.info(f'Does {cv_vcf_path} exist? {cv_vcf_existence_outcome}')
 
-        rv_vcf_path = output_path(
-            f'vds-{vds_name}/{chromosome}_rare_variants.vcf.bgz'
-        )
+        rv_vcf_path = output_path(f'vds-{vds_name}/{chromosome}_rare_variants.vcf.bgz')
         rv_vcf_existence_outcome = can_reuse(rv_vcf_path)
         logging.info(f'Does {cv_vcf_path} exist? {rv_vcf_existence_outcome}')
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -114,7 +114,6 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
     if to_path(checkpoint_path).exists():
         logging.info(f'{checkpoint_path} exists')
 
-
     return mt
 
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -114,8 +114,6 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
     if to_path(checkpoint_path).exists():
         logging.info(f'{checkpoint_path} exists')
 
-    # delete the temp checkpoint
-    hl.current_backend().fs.rmtree(temp_checkpoint_path)
 
     return mt
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -298,7 +298,7 @@ def main(
             add_remove_chr_and_index_job(rv_vcf_path)
 
     # subset variants for variance ratio estimation
-    vre_plink_path = output_path(f'vds-{vds_name}/vre_plink_2000_variants')
+    vre_plink_path = output_path(f'vds-{vds_name}/vre_plink_2000_variants', 'analysis')
     vre_bim_path = f'{vre_plink_path}.bim'
     plink_existence_outcome = can_reuse(vre_bim_path)
     logging.info(f'Does {vre_bim_path} exist? {plink_existence_outcome}')

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -21,7 +21,7 @@ analysis-runner \
     --description "get common variant VCF" \
     --dataset "bioheart" \
     --access-level "test" \
-    --output-dir "saige-qtl/bioheart_only/input_files/genotypes" \
+    --output-dir "saige-qtl/bioheart/input_files/genotypes" \
     python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds --chromosomes chr1,chr2,chr22 --vre-mac-threshold 1
 
 In main:
@@ -83,6 +83,10 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
         logging.info(f'Writing new temp checkpoint to {temp_checkpoint_path}')
         mt = mt.checkpoint(temp_checkpoint_path, overwrite=True)
 
+    #debug
+    if to_path(temp_checkpoint_path).exists():
+        logging.info(f'WE WROTE TO the TEMPORARY CHECKPOINT: {temp_checkpoint_path}')
+
     # unless forced, if the data exists, read it
     elif (
         to_path(temp_checkpoint_path).exists()
@@ -103,8 +107,17 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
         temp_checkpoint_path, _n_partitions=mt.count_rows() // VARS_PER_PARTITION or 1
     ).write(checkpoint_path, overwrite=True)
 
+    # trying to debug - check the checkpoint_path exists
+    if to_path(checkpoint_path).exists():
+        logging.info(f'WE WROTE TO THE PERMANENT CHECKPOINT:{checkpoint_path}')
+
+
     # delete the temp checkpoint
     hl.current_backend().fs.rmtree(temp_checkpoint_path)
+
+    # trying to debug
+    if not to_path(temp_checkpoint_path).exists():
+        logging.info('WE DELETED THE TEMP CHECKPOINT')
 
     return mt
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -83,9 +83,10 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
         logging.info(f'Writing new temp checkpoint to {temp_checkpoint_path}')
         mt = mt.checkpoint(temp_checkpoint_path, overwrite=True)
 
-        #debug
         if to_path(temp_checkpoint_path).exists():
-            logging.info(f'WE WROTE TO the TEMPORARY CHECKPOINT: {temp_checkpoint_path}')
+            logging.info(
+                f'Completed writing to temp checkpoint: {temp_checkpoint_path}'
+            )
 
     # unless forced, if the data exists, read it
     elif (
@@ -103,27 +104,18 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
     )
 
     # repartition to a reasonable number of partitions, then re-write
-    #hl.read_matrix_table(
-        #temp_checkpoint_path).write(checkpoint_path, overwrite=True)
-
-    # repartition to a reasonable number of partitions, then re-write
     num_rows = mt.count_rows()
     mt = hl.read_matrix_table(
         temp_checkpoint_path, _n_partitions=num_rows // VARS_PER_PARTITION or 1
     )
     mt.write(checkpoint_path)
 
-    # trying to debug - check the checkpoint_path exists
+    # check the checkpoint_path exists
     if to_path(checkpoint_path).exists():
-       logging.info(f'WE WROTE TO THE PERMANENT CHECKPOINT:{checkpoint_path}')
-
+        logging.info(f'{checkpoint_path} exists')
 
     # delete the temp checkpoint
-    #hl.current_backend().fs.rmtree(temp_checkpoint_path)
-
-    # trying to debug
-    if to_path(temp_checkpoint_path).exists():
-        logging.info('TEMP CHECKPOINT EXISTS at the end of the method')
+    hl.current_backend().fs.rmtree(temp_checkpoint_path)
 
     return mt
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -106,9 +106,16 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
     #hl.read_matrix_table(
         #temp_checkpoint_path).write(checkpoint_path, overwrite=True)
 
+    # repartition to a reasonable number of partitions, then re-write
+    num_rows = mt.count_rows()
+    mt = hl.read_matrix_table(
+        temp_checkpoint_path, _n_partitions=num_rows // VARS_PER_PARTITION or 1
+    )
+    mt.write(checkpoint_path)
+
     # trying to debug - check the checkpoint_path exists
-    #if to_path(checkpoint_path).exists():
-       #logging.info(f'WE WROTE TO THE PERMANENT CHECKPOINT:{checkpoint_path}')
+    if to_path(checkpoint_path).exists():
+       logging.info(f'WE WROTE TO THE PERMANENT CHECKPOINT:{checkpoint_path}')
 
 
     # delete the temp checkpoint

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -21,8 +21,8 @@ analysis-runner \
     --description "get common variant VCF" \
     --dataset "bioheart" \
     --access-level "test" \
-    --output-dir "saige-qtl/input_files/genotypes/" \
-    python3 get_genotype_vcf.py --vds-path=gs:// --chromosomes chr1,chr2,chr22 --vre-mac-threshold 1
+    --output-dir "saige-qtl/bioheart_only/input_files/genotypes" \
+    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds --chromosomes chr1,chr2,chr22 --vre-mac-threshold 1
 
 In main:
 
@@ -240,7 +240,7 @@ def main(
             # filter out related samples
             # this will get dropped as the vds file will already be clean
             related_ht = hl.read_table(
-                'gs://cpg-bioheart-main-analysis/large_cohort/v1-0/relateds_to_drop.ht'
+                'gs://cpg-bioheart-test/large_cohort/v1-0/relateds_to_drop.ht'
             )
             related_samples = related_ht.s.collect()
             related_samples = hl.literal(related_samples)

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -75,7 +75,7 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
         return hl.read_matrix_table(checkpoint_path)
 
     # create a temp checkpoint path
-    temp_checkpoint_path = checkpoint_path + '.temp'
+    temp_checkpoint_path = checkpoint_path.split('.')[0] + '_temp.mt'
     logging.info(f'Checkpoint temp: {temp_checkpoint_path}')
 
     # either force an overwrite, or write the first version
@@ -83,9 +83,9 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
         logging.info(f'Writing new temp checkpoint to {temp_checkpoint_path}')
         mt = mt.checkpoint(temp_checkpoint_path, overwrite=True)
 
-    #debug
-    if to_path(temp_checkpoint_path).exists():
-        logging.info(f'WE WROTE TO the TEMPORARY CHECKPOINT: {temp_checkpoint_path}')
+        #debug
+        if to_path(temp_checkpoint_path).exists():
+            logging.info(f'WE WROTE TO the TEMPORARY CHECKPOINT: {temp_checkpoint_path}')
 
     # unless forced, if the data exists, read it
     elif (
@@ -103,20 +103,20 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
     )
 
     # repartition to a reasonable number of partitions, then re-write
-    hl.read_matrix_table(
-        temp_checkpoint_path).write(checkpoint_path, overwrite=True)
+    #hl.read_matrix_table(
+        #temp_checkpoint_path).write(checkpoint_path, overwrite=True)
 
     # trying to debug - check the checkpoint_path exists
-    if to_path(checkpoint_path).exists():
-        logging.info(f'WE WROTE TO THE PERMANENT CHECKPOINT:{checkpoint_path}')
+    #if to_path(checkpoint_path).exists():
+       #logging.info(f'WE WROTE TO THE PERMANENT CHECKPOINT:{checkpoint_path}')
 
 
     # delete the temp checkpoint
-    hl.current_backend().fs.rmtree(temp_checkpoint_path)
+    #hl.current_backend().fs.rmtree(temp_checkpoint_path)
 
     # trying to debug
-    if not to_path(temp_checkpoint_path).exists():
-        logging.info('WE DELETED THE TEMP CHECKPOINT')
+    if to_path(temp_checkpoint_path).exists():
+        logging.info('TEMP CHECKPOINT EXISTS at the end of the method')
 
     return mt
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -104,8 +104,7 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
 
     # repartition to a reasonable number of partitions, then re-write
     hl.read_matrix_table(
-        temp_checkpoint_path, _n_partitions=mt.count_rows() // VARS_PER_PARTITION or 1
-    ).write(checkpoint_path, overwrite=True)
+        temp_checkpoint_path).write(checkpoint_path, overwrite=True)
 
     # trying to debug - check the checkpoint_path exists
     if to_path(checkpoint_path).exists():

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -314,7 +314,6 @@ def main(
     vre_plink_path = f'{genotype_files_prefix}/{vds_version}/vre_plink_2000_variants'
 
     for chromosome in chromosomes:
-
         # genotype vcf files are one per chromosome
         vcf_file_path = f'{genotype_files_prefix}/{vds_version}/{chromosome}_common_variants.vcf.bgz'
         # cis window files are split by gene but organised by chromosome also
@@ -323,7 +322,6 @@ def main(
         cis_window_size = get_config()['saige']['cis_window_size']
 
         for celltype in celltypes:
-
             # extract gene list based on genes for which we have pheno cov files
             pheno_cov_files_path_ct_chrom = (
                 f'{pheno_cov_files_path}/{celltype}/{chromosome}'


### PR DESCRIPTION
The current implementation allows users to specify the VDS version only (assumes that a joint TOB+BioHEART analysis will be performed). 

Here I amend the param to specify the VDS path, allowing more flexibility to specify which VDS to be used (TOB-only, BioHEART-only, or combined VDS). 

Also debugged the re-partitioning of the checkpointed matrix tables in `checkpoint_mt()`

