### PR TITLE
Check for finished MT first

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -68,8 +68,8 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
 
     # if we generated the full checkpoint, read and return
     if (
-            to_path(checkpoint_path).exists()
-            and (to_path(checkpoint_path) / '_SUCCESS').exists()
+        to_path(checkpoint_path).exists()
+        and (to_path(checkpoint_path) / '_SUCCESS').exists()
     ):
         logging.info(f'Reading non-temp checkpoint from {checkpoint_path}')
         return hl.read_matrix_table(checkpoint_path)

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -101,7 +101,7 @@ def checkpoint_mt(mt: hl.MatrixTable, checkpoint_path: str, force: bool = False)
     # repartition to a reasonable number of partitions, then re-write
     hl.read_matrix_table(
         temp_checkpoint_path, _n_partitions=mt.count_rows() // VARS_PER_PARTITION or 1
-    ).write(checkpoint_path)
+    ).write(checkpoint_path, overwrite=True)
 
     # delete the temp checkpoint
     hl.current_backend().fs.rmtree(temp_checkpoint_path)


### PR DESCRIPTION
Changes Checkpoint logic:

- start with the path of the final checkpoint to create
- if it exists, read, return, done
- if it doesn't, check if a temp checkpoint exists, write if required
- then generate the final checkpoint from the temp 
- then delete temp

The previous logic didn't check for a finished MT first, so it wrote the temp even if it didn't need to