### PR TITLE
More flexible params for get anndata, removal of dummy variables for `sequencing_library` and `cohort`

### DIFF
--- a/get_anndata.py
+++ b/get_anndata.py
@@ -87,7 +87,7 @@ def get_gene_cis_info(
     gene_info_df = copy_h5ad_local_and_open(gene_info_df_path).var
 
     # select the gene from df
-    gene_info_gene = gene_info_df[gene_info_df['gene_name'] == gene]
+    gene_info_gene = gene_info_df[gene_info_df.index == gene]
     # get gene chromosome
     chrom = gene_info_gene['chr'][0]
     # remove "chr"
@@ -152,7 +152,7 @@ def make_pheno_cov(
         sample_covs_cells_df['age'] = sample_covs_cells_df['age'].fillna(mean_age)
     # drop rows with missing values (SAIGE throws an error otherwise:  https://batch.hail.populationgenomics.org.au/batches/435978/jobs/91)
     sample_covs_cells_df = sample_covs_cells_df.dropna()
-    gene_adata = expression_adata[:, expression_adata.var['gene_name'] == gene]
+    gene_adata = expression_adata[:, expression_adata.var.index == gene]
     gene_name = gene.replace("-", "_")
     expr_df = pd.DataFrame(
         data=gene_adata.X.todense(), index=gene_adata.obs.index, columns=[gene_name]
@@ -304,7 +304,7 @@ def main(
             subprocess.run(cmd, check=True)
 
             # start up some jobs for each gene
-            for gene in expression_adata.var['gene_name']:
+            for gene in expression_adata.var.index:
                 # change hyphens to underscore for R usage
                 gene_name = gene.replace("-", "_")
                 # make pheno cov file

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -24,7 +24,7 @@ analysis-runner \
     --anndata-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_anndata \
     --celltype-covs-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_cell_covs \
     --sample-covs-file gs://cpg-bioheart-test/str/associatr/bioheart_n990/input_files/bioheart_covariates_str_run_v1.csv \
-    --concurrent-job-cap=350
+    --concurrent-job-cap=350 --pc-job-cpu=2
 
 
 """
@@ -332,7 +332,7 @@ def main(
                     gene_cis_job = get_batch().new_python_job(
                         name=f'gene cis file: {gene}'
                     )
-                    gene_cis_job.cpu(0.5)
+                    gene_cis_job.cpu(2)
 
                     gene_cis_job.call(
                         get_gene_cis_info,

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -177,9 +177,9 @@ def copy_h5ad_local_and_open(adata_path: str) -> sc.AnnData:
 @click.option('--chromosomes')
 @click.option('--anndata-files-prefix', default='saige-qtl/anndata_objects_from_HPC')
 @click.option(
-    '--celltype-covs-files-prefix', default='saige-qtl/celltype_covs_from_HPC'
+    '--celltype-covs-files-prefix', help = 'GCP path to celltype covariates file directory'
 )
-@click.option('--sample-covs-files-prefix', default='saige-qtl/input_files/covariates')
+@click.option('--sample-covs-file', help='GCP path to sample covariates file')
 @click.option('--min-pct-expr', type=int, default=1)
 @click.option('--cis-window-size', type=int, default=100000)
 @click.option(
@@ -209,7 +209,7 @@ def main(
     chromosomes: str,
     anndata_files_prefix: str,
     celltype_covs_files_prefix: str,
-    sample_covs_files_prefix: str,
+    sample_covs_file: str,
     min_pct_expr: int,
     cis_window_size: int,
     concurrent_job_cap: int,
@@ -240,25 +240,21 @@ def main(
 
     # sample level covariates (age + sex + genotype PCs)
     # age from metamist, sex from somalier + Vlad's file for now
-    sample_covs_file = dataset_path(
-        f'{sample_covs_files_prefix}/sex_age_geno_pcs_tob_bioheart.csv', 'analysis'
-    )
+
 
     for celltype in celltypes.split(','):
 
         # extract cell-level covariates
         # expression PCs, cell type specific
-        celltype_covs_file = dataset_path(
-            f'{celltype_covs_files_prefix}/{celltype}_expression_pcs.csv'
-        )
+        celltype_covs_file = f'{celltype_covs_files_prefix}/{celltype}_expression_pcs.csv'
+
 
         for chromosome in chromosomes.split(','):
             chrom_len = hl.get_reference('GRCh38').lengths[chromosome]
 
             # copy in h5ad file to local, then load it
-            expression_h5ad_path = dataset_path(
-                f'{anndata_files_prefix}/{celltype}_{chromosome}.h5ad'
-            )
+            expression_h5ad_path = f'{anndata_files_prefix}/{celltype}_{chromosome}.h5ad'
+
             expression_adata = copy_h5ad_local_and_open(expression_h5ad_path)
             logging.info(
                 f'AnnData for {celltype}, {chromosome} opened: {expression_adata.shape[1]} total genes'

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -19,7 +19,7 @@ analysis-runner \
     --access-level "test" \
     --output-dir "saige-qtl/input_files" \
     --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
-    python3 get_anndata.py --celltypes B_naive --chromosomes chr21 \
+    python3 get_anndata.py --celltypes B_naive --chromosomes chr22 \
     --anndata-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_anndata \
     --celltype-covs-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_cell_covs \
     --sample-covs-file gs://cpg-bioheart-test/str/associatr/bioheart_n990/input_files/bioheart_covariates_str_run_v1.csv
@@ -292,8 +292,6 @@ def main(
             tmp_path = join(get_config()['storage']['default']['tmp'], tmp_adata_name)
             cmd = ["gsutil", "cp", tmp_adata_name, tmp_path]
             subprocess.run(cmd, check=True)
-
-
 
             # start up some jobs for each gene
             for gene in expression_adata.var['gene_name']:

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -38,6 +38,7 @@ import scanpy as sc
 from os.path import join
 from pathlib import Path
 from typing import List
+import subprocess
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
@@ -289,8 +290,9 @@ def main(
 
             # then write that to GCP
             tmp_path = join(get_config()['storage']['default']['tmp'], tmp_adata_name)
-            local_tmp_adata = get_batch().read_input(tmp_adata_name)
-            get_batch().write_output(local_tmp_adata, tmp_path)
+            cmd = ["gsutil", "cp", tmp_adata_name, tmp_path]
+            subprocess.run(cmd, check=True)
+
 
 
             # start up some jobs for each gene

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -289,10 +289,9 @@ def main(
 
             # then write that to GCP
             tmp_path = join(get_config()['storage']['default']['tmp'], tmp_adata_name)
-            with open(tmp_adata_name, 'rb') as reader:
-                with hl.hadoop_open(tmp_path, 'wb') as writer:
-                    for line in reader:
-                        writer.write(line)
+            local_tmp_adata = get_batch().read_input(tmp_adata_name)
+            get_batch().write_output(local_tmp_adata, tmp_path)
+
 
             # start up some jobs for each gene
             for gene in expression_adata.var['gene_name']:

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -12,17 +12,19 @@ these files will be used as inputs for the
 SAIGE-QTL association pipeline.
 
 To run:
-
+chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22 \
 analysis-runner \
     --description "make expression input files" \
     --dataset "bioheart" \
     --access-level "test" \
-    --output-dir "saige-qtl/input_files" \
+    --output-dir "saige-qtl/bioheart_n990/input_files" \
+    --memory='16G' \
     --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
-    python3 get_anndata.py --celltypes B_naive --chromosomes chr22 \
+    python3 get_anndata.py --celltypes CD4_TCM --chromosomes chr1\
     --anndata-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_anndata \
     --celltype-covs-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_cell_covs \
-    --sample-covs-file gs://cpg-bioheart-test/str/associatr/bioheart_n990/input_files/bioheart_covariates_str_run_v1.csv
+    --sample-covs-file gs://cpg-bioheart-test/str/associatr/bioheart_n990/input_files/bioheart_covariates_str_run_v1.csv \
+    --concurrent-job-cap=350
 
 
 """
@@ -330,7 +332,7 @@ def main(
                     gene_cis_job = get_batch().new_python_job(
                         name=f'gene cis file: {gene}'
                     )
-                    gene_cis_job.cpu(0.25)
+                    gene_cis_job.cpu(0.5)
 
                     gene_cis_job.call(
                         get_gene_cis_info,

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -18,9 +18,10 @@ analysis-runner \
     --dataset "bioheart" \
     --access-level "test" \
     --output-dir "saige-qtl/bioheart_n990/input_files" \
-    --memory='16G' \
+    --memory='64G' \
+    --storage='100G'\
     --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
-    python3 get_anndata.py --celltypes CD4_TCM --chromosomes chr1\
+    python3 get_anndata.py --celltypes CD4_TCM --chromosomes chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22 \
     --anndata-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_anndata \
     --celltype-covs-files-prefix gs://cpg-bioheart-test/str/240_libraries_tenk10kp1_v2/cpg_cell_covs \
     --sample-covs-file gs://cpg-bioheart-test/str/associatr/bioheart_n990/input_files/bioheart_covariates_str_run_v1.csv \
@@ -221,6 +222,12 @@ def copy_h5ad_local_and_open(adata_path: str) -> sc.AnnData:
     default='standard',
     help='Memory for each pheno cov job',
 )
+@click.option(
+    '--cis-job-cpu',
+    type=float,
+    default=0.25,
+    help='CPU for each cis window job',
+)
 def main(
     celltypes: str,
     chromosomes: str,
@@ -232,6 +239,7 @@ def main(
     concurrent_job_cap: int,
     pc_job_cpu: float,
     pc_job_mem: str,
+    cis_job_cpu: float,
 ):
     """
     Run expression processing pipeline
@@ -332,7 +340,7 @@ def main(
                     gene_cis_job = get_batch().new_python_job(
                         name=f'gene cis file: {gene}'
                     )
-                    gene_cis_job.cpu(2)
+                    gene_cis_job.cpu(cis_job_cpu)
 
                     gene_cis_job.call(
                         get_gene_cis_info,

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -216,7 +216,6 @@ def main(
     vds = hl.vds.read_vds(vds_path)
 
     for chromosome in chromosomes.split(','):
-
         # create paths and check if they exist already
         cv_vcf_path = output_path(
             f'vds{vds_version}/{chromosome}_common_variants.vcf.bgz'
@@ -231,7 +230,6 @@ def main(
         logging.info(f'Does {cv_vcf_path} exist? {rv_vcf_existence_outcome}')
 
         if not cv_vcf_existence_outcome or not rv_vcf_existence_outcome:
-
             # consider only relevant chromosome
             chrom_vds = hl.vds.filter_chromosomes(vds, keep=chromosome)
 

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -314,7 +314,6 @@ def main(
     vre_plink_path = f'{genotype_files_prefix}/{vds_version}/vre_plink_2000_variants'
 
     for chromosome in chromosomes:
-
         # genotype vcf files are one per chromosome
         vcf_file_path = f'{genotype_files_prefix}/{vds_version}/{chromosome}_common_variants.vcf.bgz'
         # cis window files are split by gene but organised by chromosome also
@@ -323,7 +322,6 @@ def main(
         cis_window_size = get_config()['saige']['cis_window_size']
 
         for celltype in celltypes:
-
             # extract gene list based on genes for which we have pheno cov files
             pheno_cov_files_path_ct_chrom = (
                 f'{pheno_cov_files_path}/{celltype}/{chromosome}'


### PR DESCRIPTION
Changes: 
1) More flexible params for the script:
- specifying the GCP paths for the cell type and sample level covariate files as well as for the anndata files. 


2) Remove:
- `sequencing_library` dummy variables because they will no longer be included in the model - expensive to run for freeze 1, possible consider for freeze 2; cost scales pretty much linearly with every additional covariate we add to the model. 
- `cohort` dummy variable because cohort-specific analysis will be conducted
(these pertain to the make_pheno_cov() helper method) 

3) Use `subprocess` to copy the filtered h5ad file to GCP instead of the existing hl.hadoop read/write because the latter produced error - https://batch.hail.populationgenomics.org.au/batches/444912/jobs/1

4) Do not loop over `gene_name` in the H5AD file because some genes with distinct ENSG IDs have the same `gene_name` entry so the job will fail. Instead, we now loop over expression_adata.var.index. See failed jobs here -https://batch.hail.populationgenomics.org.au/batches/445040?q=state%3Dfailed

fyi @annacuomo 

TODO: When scRNA freeze 2 comes, we need to delete the code that amends the cell barcode suffix. Cell barcodes dont' currently match between H5AD file and the cell covariate file because one of them has the sequencing library attached as as suffix and the other doesn't (Blake has been informed)
