### PR TITLE
Add config param to drop certain genes from the SAIGE step 3

### DIFF
--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -19,12 +19,14 @@ To run:
 analysis-runner \
     --config saige_assoc_test.toml \
     --description "SAIGE-QTL association pipeline" \
+    --memory='32G' \
+    --storage='50G' \
     --dataset "bioheart" \
     --access-level "full" \
     --output-dir "saige-qtl/bioheart_n990/v1" \
      python3 saige_assoc.py \
-     --pheno-cov-files-path=gs://cpg-bioheart-test/saige-qtl/bioheart_n990/input_files/pheno_cov_files \
-        --cis-window-files-path=gs://cpg-bioheart-test/saige-qtl/bioheart_n990/input_files/cis_window_files \
+     --pheno-cov-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/v1/pheno_cov_files \
+        --cis-window-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/v1/cis_window_files \
         --genotype-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/vds-bioheart1-0 \
         --vre-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/vds-bioheart1-0
 
@@ -361,6 +363,10 @@ def main(
 
             genes = [f.replace(f'_{celltype}_pheno_cov.tsv', '') for f in files]
             logging.info(f'I found these genes: {", ".join(genes)}')
+
+            drop_genes: list[str] = get_config()['saige']['drop_genes']
+
+            genes = [x for x in genes if x not in drop_genes]
 
             # extract relevant gene-related files
             for gene in genes:

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,10 +1,11 @@
 [saige]
 # principal arguments
 celltypes = ['CD4_TCM']
-chromosomes = ['chr1']
+chromosomes = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr9','chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17','chr18','chr19','chr20','chr21','chr22']
+drop_genes =[]
 
 # secondary arguments
-max_parallel_jobs = 150
+max_parallel_jobs = 350
 cis_window_size = 100000
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
@@ -40,7 +41,8 @@ LOCO = 'FALSE'
 markers_per_chunk = 10000
 SPAcutoff = 10000
 [saige.job_specs.sv_test]
-cpu = 2
+cpu = 1
+storage = '12G'
 [saige.job_specs.fit_null]
 storage = "0G"
 memory = "4Gi"


### PR DESCRIPTION
Certain genes are failing to converge in step 1 - leads to massive cancellation of other unrelated jobs https://centrepopgen.slack.com/archives/C030X7WGFCL/p1714947441042869 because of the concurrency cap which makes jobs dependent on each other. 

Here we explicitly define which genes not to run on so that when the batch job is re-run we can exclude problematic genes and get more jobs to run successfully. 