### PR TITLE
Add sentinels (fake jobs) so that we can do `always_run()` but also cancel the jobs if needed. 

### DIFF
--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -147,7 +147,7 @@ def build_run_single_variant_test_command(
     # write the output
     get_batch().write_output(second_job.output, output_path)
 
-    return second_job, second_job.output
+    return fake_second_job, second_job.output
 
 
 # Combine single variant associations at gene level (step 3)
@@ -185,7 +185,7 @@ def build_obtain_gene_level_pvals_command(
     saige_job.image(image_path('saige-qtl'))
     saige_job.command(saige_command_step3)
     get_batch().write_output(saige_job.output, saige_gene_pval_output_file)
-    return saige_job
+    return fake_third_job
 
 
 def apply_job_settings(job: hb.batch.job.Job, job_name: str):
@@ -265,7 +265,7 @@ def run_fit_null_job(
     if null_output_path:
         get_batch().write_output(gene_job.output, null_output_path)
 
-    return gene_job, gene_job.output
+    return fake_gene_job, gene_job.output
 
 
 def summarise_cv_results(


### PR DESCRIPTION
I think this is right....? 

Added sentinel jobs to each of the four steps: 
1. Fitting the null model `run_fit_null_job`
2. ` build_run_single_variant_test_command`
3. `build_obtain_gene_level_pvals_command`
4. `summarise_cv_results` (sentinel added in `main()`) 

Ensured that the sentinel job was the one being returned in steps 1,2,3 (ie we want to add the sentinel jobs to `manage_concurrency_for_job`) 
