### PR TITLE
Add image path to step 1 job

### DIFF
--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -230,6 +230,7 @@ def run_fit_null_job(
         )
 
     gene_job = get_batch().new_job(name="saige-qtl part 1")
+    gene_job.image(image_path('saige-qtl'))
     apply_job_settings(gene_job, 'fit_null')
 
     # create output group for first command in gene job


### PR DESCRIPTION
I must have mistakenly deleted the image path to the saige-qtl container for step 1. 

Erroring out because it can't find the Rscript: https://batch.hail.populationgenomics.org.au/batches/446131/jobs/7346