### PR TITLE
sample id is no longer a col, but is the index

### DIFF
--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -169,7 +169,7 @@ def main(
     combined_sex_age_pcs = pd.concat([sex_df, age_df, pcs_df], axis=1)
 
     # add permuted sample ids for calibration analysis
-    samples = combined_sex_age_pcs['sample_id']
+    samples = combined_sex_age_pcs.index
     for i in range(number_of_sample_perms):
         combined_sex_age_pcs[f'sample_perm{i}'] = shuffle(
             samples.values, random_state=i


### PR DESCRIPTION
Small mistake when doing this, sample_id is no longer a column in the combined dataframe (it gets dropped above) but is the index, see for example file in `cpg-bioheart-main-analysis/saige-qtl/input_files/covariates/sex_age_geno_pcs_tob_bioheart.csv`