### PR TITLE
remove related before making vre files also

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -22,7 +22,8 @@ analysis-runner \
     --dataset "bioheart" \
     --access-level "test" \
     --output-dir "saige-qtl/bioheart/input_files/genotypes" \
-    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds --chromosomes chr1,chr2,chr22 --vre-mac-threshold 1
+    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds \
+        --chromosomes chr1,chr2,chr22 --vre-mac-threshold 1 --cv-maf-threshold 0 --rv-maf-threshold 1
 
 In main:
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -22,8 +22,8 @@ analysis-runner \
     --dataset "bioheart" \
     --access-level "test" \
     --output-dir "saige-qtl/bioheart/input_files/genotypes" \
-    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds \
-        --chromosomes chr1,chr2,chr22 --vre-mac-threshold 1 --cv-maf-threshold 0 --rv-maf-threshold 1
+    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-test/vds/bioheart1-0.vds --chromosomes chr22 \
+        --cv-maf-threshold 0 --rv-maf-threshold 1 --vre-mac-threshold 1 --vre-n-markers 5
 
 In main:
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -344,6 +344,9 @@ def main(
         )
         mt = hl.variant_qc(mt)
 
+        print(vre_mac_threshold)
+        print(mt.count())
+
         # minor allele count (MAC) > {vre_mac_threshold}
         vre_mt = mt.filter_rows(mt.variant_qc.AC[1] > vre_mac_threshold)
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -249,7 +249,7 @@ def main(
 
         rv_vcf_path = output_path(f'vds-{vds_name}/{chromosome}_rare_variants.vcf.bgz')
         rv_vcf_existence_outcome = can_reuse(rv_vcf_path)
-        logging.info(f'Does {cv_vcf_path} exist? {rv_vcf_existence_outcome}')
+        logging.info(f'Does {rv_vcf_path} exist? {rv_vcf_existence_outcome}')
 
         if not cv_vcf_existence_outcome or not rv_vcf_existence_outcome:
             # consider only relevant chromosome


### PR DESCRIPTION
I noticed that there was a donor mismatch between the genotype files included in steps 1 & 2 of the SAIGE-QTL pipeline, and confirmed by counting the donors in the different files, see PR: https://github.com/populationgenomics/saige-tenk10k/pull/111 and successful run in `main` confirming mismatching numbers:  https://batch.hail.populationgenomics.org.au/batches/479015/jobs/1

I think the mismatch stems from a recent improvement where we remove related samples from the vds / mts which we export as VCF files, but I forgot to do so for the vre plink files as well, so rectifying this here.

Ran successfully in `test`: https://batch.hail.populationgenomics.org.au/batches/479073/jobs/1

And donor counter to confirm matching number of donors: https://batch.hail.populationgenomics.org.au/batches/479080/jobs/1 (there are only 5 donors in the `test` object so this will have to be further checked in `main`)