### PR TITLE
add low frequency variants

### DIFF
--- a/helper/variant_counter.py
+++ b/helper/variant_counter.py
@@ -78,7 +78,7 @@ def count_variants(
 
     # count up both donors and variants
     n_common_vars, n_donors = cv_mt.count()
-    n_low_frequency_vars, n_donors = lf_mt.count()[0]
+    n_low_frequency_vars = lf_mt.count()[0]
     n_rare_vars = rv_mt.count()[0]
 
     print(f'Donor count: {n_donors}')

--- a/helper/variant_counter.py
+++ b/helper/variant_counter.py
@@ -71,8 +71,8 @@ def count_variants(
     # select common, low-frequency and rare variants
     cv_mt = mt.filter_rows(mt.variant_qc.AF[1] >= cv_maf_threshold)
     lf_mt = mt.filter_rows(
-        mt.variant_qc.AF[1] >= rv_maf_threshold
-        and mt.variant_qc.AF[1] < cv_maf_threshold
+        (mt.variant_qc.AF[1] >= rv_maf_threshold)
+        & (mt.variant_qc.AF[1] < cv_maf_threshold)
     )
     rv_mt = mt.filter_rows(mt.variant_qc.AF[1] < rv_maf_threshold)
 

--- a/helper/variant_counter.py
+++ b/helper/variant_counter.py
@@ -11,7 +11,7 @@ similar to tob-wgs/scripts/rv_expression_association/count_variants.py
 To run:
 
 analysis-runner \
-    --description "count common and rare variant VCFs" \
+    --description "count common, low freq and rare variant VCFs" \
     --dataset "bioheart" \
     --access-level "full" \
     --output-dir "saige-qtl/" \
@@ -21,8 +21,9 @@ analysis-runner \
 import click
 
 import hail as hl
+import pandas as pd
 
-from cpg_utils.hail_batch import init_batch
+from cpg_utils.hail_batch import init_batch, output_path
 
 
 @click.command()
@@ -76,15 +77,40 @@ def count_variants(
     rv_mt = mt.filter_rows(mt.variant_qc.AF[1] < rv_maf_threshold)
 
     # count up both donors and variants
-    n_vars, n_donors = cv_mt.count()
+    n_common_vars, n_donors = cv_mt.count()
+    n_low_frequency_vars, n_donors = lf_mt.count()[0]
+    n_rare_vars = rv_mt.count()[0]
 
     print(f'Donor count: {n_donors}')
 
-    print(f'Common variant (MAF>={cv_maf_threshold}) count: {n_vars}')
+    print(f'Common variant (MAF>={cv_maf_threshold}) count: {n_common_vars}')
     print(
-        f'low-frequency variant (MAF >={rv_maf_threshold} and <{cv_maf_threshold}) count: {lf_mt.count()[0]}'
+        f'low-frequency variant (MAF >={rv_maf_threshold} and <{cv_maf_threshold}) count: {n_low_frequency_vars}'
     )
-    print(f'Rare variant (MAF<{rv_maf_threshold}) count: {rv_mt.count()[0]}')
+    print(f'Rare variant (MAF<{rv_maf_threshold}) count: {n_rare_vars}')
+
+    variant_counter_df = pd.DataFrame(
+        {
+            'vds_name': vds_name,
+            'donor_count': n_donors,
+            'rare_variant_maf_threshold': rv_maf_threshold,
+            'common_variant_maf_threshold': cv_maf_threshold,
+            f'rare_variant_count (MAF<{rv_maf_threshold})': n_common_vars,
+            f'low_frequency_variant_count (MAF >={rv_maf_threshold} and <{cv_maf_threshold})': n_low_frequency_vars,
+            f'common_variant_count (MAF>={cv_maf_threshold})': n_common_vars,
+        }
+    )
+    # save variant counts to file
+    variant = 'variant'
+    if exclude_multiallelic:
+        variant = f'no_multiallelic_{variant}'
+    if exclude_indels:
+        variant = f'no_indels_{variant}'
+    variant_counter_out_file = output_path(
+        f'{vds_name}_mafs_{rv_maf_threshold}_{cv_maf_threshold}_{variant}_counts.csv',
+        'analysis',
+    )
+    variant_counter_df.to_csv(variant_counter_out_file)
 
 
 if __name__ == '__main__':

--- a/helper/variant_counter.py
+++ b/helper/variant_counter.py
@@ -90,15 +90,17 @@ def count_variants(
     print(f'Rare variant (MAF<{rv_maf_threshold}) count: {n_rare_vars}')
 
     variant_counter_df = pd.DataFrame(
-        {
-            'vds_name': vds_name,
-            'donor_count': n_donors,
-            'rare_variant_maf_threshold': rv_maf_threshold,
-            'common_variant_maf_threshold': cv_maf_threshold,
-            f'rare_variant_count (MAF<{rv_maf_threshold})': n_common_vars,
-            f'low_frequency_variant_count (MAF >={rv_maf_threshold} and <{cv_maf_threshold})': n_low_frequency_vars,
-            f'common_variant_count (MAF>={cv_maf_threshold})': n_common_vars,
-        }
+        [
+            {
+                'vds_name': vds_name,
+                'donor_count': n_donors,
+                'rare_variant_maf_threshold': rv_maf_threshold,
+                'common_variant_maf_threshold': cv_maf_threshold,
+                f'rare_variant_count (MAF<{rv_maf_threshold})': n_rare_vars,
+                f'low_frequency_variant_count (MAF >={rv_maf_threshold} and <{cv_maf_threshold})': n_low_frequency_vars,
+                f'common_variant_count (MAF>={cv_maf_threshold})': n_common_vars,
+            }
+        ]
     )
     # save variant counts to file
     variant = 'variant'


### PR DESCRIPTION
Add ability to count variants near the common frequency threshold as well.

Noting that Matt commented on this in an old PR (https://github.com/populationgenomics/saige-tenk10k/pull/68), highlighting how more checkpoints should be used I think, to avoid duplicated computation? Any help there would be useful, but also as I noted in that PR these operations are very cheap.