### PR TITLE
add variant ids to vcf based on other cols

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -162,7 +162,7 @@ def add_remove_chr_and_index_job(vcf_path):
     )
     bcftools_job.command(
         f"""
-        bcftools annotate --rename-chrs chr_update.txt {vcf_input} | \\
+        bcftools annotate --rename-chrs chr_update.txt --set-id +'%CHROM\_%POS\_%REF\_%FIRST_ALT' {vcf_input} | \\
         bgzip -c > {bcftools_job.output['vcf.bgz']}
         bcftools index -c {bcftools_job.output['vcf.bgz']}
     """


### PR DESCRIPTION
The pipeline finally ran successfully, but I noticed the final summary file `cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/v3/output_files/summary_stats/B_naive_all_cis_cv_results.tsv` has `.` for `top_MarkerID` because the `ID` column of the VCFs I am testing is empty.

So going back to the script generating these VCF files and annotating them using bcftools so that the variant ID includes info on chrom, pos, ref and alt alleles in the form `{chrom}_{pos}_{ref}_{alt}`.