### PR TITLE
Updating output files path for eQTL analysis

### DIFF
--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -386,7 +386,7 @@ def main(
 
                 # check if these outputs already exist, if so don't make a new job
                 null_job, null_output = run_fit_null_job(
-                    output_path(f'output_files/{celltype}_{gene}'),
+                    output_path(f'{celltype}/{chromosome}/{celltype}_{gene}'),
                     pheno_file=pheno_cov_path,
                     plink_path=vre_plink_path,
                     pheno_col=gene,
@@ -398,7 +398,7 @@ def main(
                 # step 2 (cis eQTL single variant test)
                 step2_job, step2_output = build_run_single_variant_test_command(
                     output_path=output_path(
-                        f'output_files/{celltype}_{gene}_cis', 'analysis'
+                        f'{celltype}/{chromosome}/{celltype}_{gene}_cis', 'analysis'
                     ),
                     vcf_file=vcf_file_path,
                     chrom=(chromosome[3:]),
@@ -415,7 +415,7 @@ def main(
                     gene_name=gene,
                     saige_sv_output_file=step2_output,
                     saige_gene_pval_output_file=output_path(
-                        f'output_files/{celltype}_{gene}_cis_gene_pval'
+                        f'{celltype}/{chromosome}/{celltype}_{gene}_cis_gene_pval'
                     ),
                 )
 
@@ -431,7 +431,7 @@ def main(
     for celltype in celltypes:
         logging.info(f'start summarising results for {celltype}')
         summary_output_path = (
-            f'output_files/summary_stats/{celltype}_all_cis_cv_results.tsv'
+            f'summary_stats/{celltype}_all_cis_cv_gene_level_results.tsv'
         )
 
         summarise_job = get_batch().new_python_job(

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -272,7 +272,7 @@ def summarise_cv_results(
 
     existing_cv_assoc_results = [
         str(file)
-        for file in to_path(gene_results_path).glob(f'{celltype}_*_cis_gene_pval')
+        for file in to_path(gene_results_path).glob(f'*/{celltype}_*_cis_gene_pval')
     ]
     results_all_df = pd.concat(
         [
@@ -441,7 +441,7 @@ def main(
         summarise_job.call(
             summarise_cv_results,
             celltype=celltype,
-            gene_results_path=output_path('output_files/'),
+            gene_results_path=output_path(celltype),
             out_path=summary_output_path,
         )
     # set jobs running

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -12,7 +12,7 @@ cis_window_size = 100000
 [saige.build_fit_null]
 covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,total_counts'
 sampleCovarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5'
-sampleIDColinphenoFile = 'sample_perm0'
+sampleIDColinphenoFile = 'individual'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal
 traitType = 'count'
 

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -12,7 +12,7 @@ cis_window_size = 100000
 [saige.build_fit_null]
 covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,total_counts'
 sampleCovarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5'
-sampleIDColinphenoFile = 'individual'
+sampleIDColinphenoFile = 'sample_perm0'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal
 traitType = 'count'
 


### PR DESCRIPTION
Results from the SAIGE-QTL pipeline ended up in an awkwardly called path with repeated `output_files` directory, e.g., `gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/output_files/v3/output_files/`, so fixing that here.
While I am at it, also split results by chromosome and cell type to make them easier to navigate. 

Because of the too-small genotype files in `test` cannot test this but hoping it is a small enough change that it is not a problem!