### PR TITLE
Summarise and plot raw p-values from SAIGE-QTL

### DIFF
--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -64,11 +64,11 @@ def plot_pvalues(
             len(df['Allele1'].values[i]) == 1 and len(df['Allele2'].values[i]) == 1
             for i in range(df.shape[0])
         ]
-        results_all_df.append(df)
+        results_all_df_list.append(df)
         # select top SNP
         df_snp = df[df['is_snp']]
         df_top_snp = df_snp[df_snp['p.value'] == df_snp['p.value'].min()]
-        results_top_snp_df.append(df_top_snp)
+        results_top_snp_df_list.append(df_top_snp)
     results_all_df = pd.concat(results_all_df_list)
     results_top_snp_df = pd.concat(results_top_snp_df_list)
 

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -20,7 +20,7 @@ import click
 import matplotlib.pyplot as plt
 import hail as hl
 
-# import numpy as np
+import numpy as np
 import pandas as pd
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path
@@ -86,14 +86,31 @@ def plot_pvalues(
 
     # plot histograms
     p_hist_all = plt.hist(results_all_df['p.value'])
-    # p_hist_top = plt.hist(results_top_snp_df['p.value'])
+    p_hist_top = plt.hist(results_top_snp_df['p.value'])
 
-    # # QQ plots
-    # expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])
-    # expected_pvals_top = np.random.uniform(
-    #     low=0, high=1, size=results_top_snp_df.shape[0]
-    # )
+    # save histograms
+    fig, _ = plt.subplots(figsize=(10, 8))
+    fig.save(p_hist_all)
+    gcs_path_p = output_path(
+        f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
+    )
+    hl.hadoop_copy('local_histo.html', gcs_path_p)
 
+    # QQ plots
+    expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])
+    expected_pvals_top = np.random.uniform(
+        low=0, high=1, size=results_top_snp_df.shape[0]
+    )
+    # all results
+    x_all = -np.log10(np.sort(expected_pvals_all))
+    y_all = -np.log10(np.sort(results_all_df['p.value']))
+    p_qq_all = plt.scatter(x_all, y_all)
+    # top SNP
+    x_top = -np.log10(np.sort(expected_pvals_top))
+    y_top = -np.log10(np.sort(results_top_snp_df['p.value']))
+    p_qq_top_snp = plt.scatter(x_top, y_top)
+
+    # save qq plots
     fig, _ = plt.subplots(figsize=(10, 8))
     fig.save(p_hist_all)
     gcs_path_p = output_path(

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -97,9 +97,6 @@ def plot_pvalues(
 
     # QQ plots
     expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])
-    # expected_pvals_top = np.random.uniform(
-    #     low=0, high=1, size=results_top_snp_df.shape[0]
-    # )
     # all results
     x_all = -np.log10(np.sort(expected_pvals_all))
     y_all = -np.log10(np.sort(results_all_df['p.value']))
@@ -107,25 +104,29 @@ def plot_pvalues(
     plt.figure(figsize=(8, 8))
     fig, ax = plt.subplots(figsize=(8, 8))
     ax.scatter(x_all, y_all)
-    fig.tight_layout()
+    # fig.tight_layout()
     fig.savefig('qqplot.png')
     gcs_path_p = output_path(
         f'plots/pvalues_qqplot/{celltype}_shuffled_all.html', 'analysis'
     )
     hl.hadoop_copy('qqplot.png', gcs_path_p)
 
-    # # top SNP
-    # x_top = -np.log10(np.sort(expected_pvals_top))
-    # y_top = -np.log10(np.sort(results_top_snp_df['p.value']))
-    # p_qq_top_snp = plt.scatter(x_top, y_top)
+    # top SNP
+    expected_pvals_top = np.random.uniform(
+        low=0, high=1, size=results_top_snp_df.shape[0]
+    )
+    x_top = -np.log10(np.sort(expected_pvals_top))
+    y_top = -np.log10(np.sort(results_top_snp_df['p.value']))
 
-    # # save qq plots
-
-    # fig.save(p_hist_all)
-    # gcs_path_p = output_path(
-    #     f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
-    # )
-    # hl.hadoop_copy('local_histo.html', gcs_path_p)
+    plt.figure(figsize=(8, 8))
+    fig, ax = plt.subplots(figsize=(8, 8))
+    ax.scatter(x_top, y_top)
+    # fig.tight_layout()
+    fig.savefig('qqplot.png')
+    gcs_path_p = output_path(
+        f'plots/pvalues_qqplot/{celltype}_shuffled_top_snp.html', 'analysis'
+    )
+    hl.hadoop_copy('qqplot.png', gcs_path_p)
 
 
 if __name__ == '__main__':

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -12,7 +12,8 @@ analysis-runner \
     --output-dir "saige-qtl/" \
     python3 plotter/summarise_and_qq_plotter.py \
         --celltype='B_naive' \
-        --results-path=gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files
+        --results-path=gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files \
+        --title='shuffled'
 """
 
 import click
@@ -28,9 +29,11 @@ from cpg_utils.hail_batch import init_batch, output_path
 @click.command()
 @click.option('--celltype', required=True)
 @click.option('--results-path', required=True)
+@click.option('--title', default='shuffled')
 def plot_pvalues(
     celltype: str,
     results_path: str,
+    title: str,
 ):
     """
     combines the results for a given cell type,
@@ -83,7 +86,7 @@ def plot_pvalues(
     plt.hist(results_all_df['p.value'])
     plt.savefig('histo.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_histo/{celltype}_shuffled_all.png', 'analysis'
+        f'plots/pvalues_histo/{celltype}_{title}_all.png', 'analysis'
     )
     hl.hadoop_copy('histo.png', gcs_path_p)
 
@@ -93,7 +96,7 @@ def plot_pvalues(
     ax.hist(results_top_snp_df['p.value'])
     fig.savefig('histo.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_histo/{celltype}_shuffled_top_snp.png', 'analysis'
+        f'plots/pvalues_histo/{celltype}_{title}_top_snp.png', 'analysis'
     )
     hl.hadoop_copy('histo.png', gcs_path_p)
 
@@ -108,7 +111,7 @@ def plot_pvalues(
     ax.scatter(x_all, y_all)
     fig.savefig('qqplot.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_qqplot/{celltype}_shuffled_all.png', 'analysis'
+        f'plots/pvalues_qqplot/{celltype}_{title}_all.png', 'analysis'
     )
     hl.hadoop_copy('qqplot.png', gcs_path_p)
 
@@ -124,7 +127,7 @@ def plot_pvalues(
     ax.scatter(x_top, y_top)
     fig.savefig('qqplot.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_qqplot/{celltype}_shuffled_top_snp.png', 'analysis'
+        f'plots/pvalues_qqplot/{celltype}_{title}_top_snp.png', 'analysis'
     )
     hl.hadoop_copy('qqplot.png', gcs_path_p)
 

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -93,7 +93,7 @@ def plot_pvalues(
     plt.hist(results_all_df['p.value'])
     plt.savefig('histo.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_histo/{celltype}_shuffled_all.html', 'analysis'
+        f'plots/pvalues_histo/{celltype}_shuffled_all.png', 'analysis'
     )
     hl.hadoop_copy('histo.png', gcs_path_p)
 
@@ -104,7 +104,7 @@ def plot_pvalues(
     # fig.tight_layout()
     fig.savefig('histo.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_histo/{celltype}_shuffled_top_snp.html', 'analysis'
+        f'plots/pvalues_histo/{celltype}_shuffled_top_snp.png', 'analysis'
     )
     hl.hadoop_copy('histo.png', gcs_path_p)
 
@@ -120,7 +120,7 @@ def plot_pvalues(
     # fig.tight_layout()
     fig.savefig('qqplot.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_qqplot/{celltype}_shuffled_all.html', 'analysis'
+        f'plots/pvalues_qqplot/{celltype}_shuffled_all.png', 'analysis'
     )
     hl.hadoop_copy('qqplot.png', gcs_path_p)
 
@@ -137,7 +137,7 @@ def plot_pvalues(
     # fig.tight_layout()
     fig.savefig('qqplot.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_qqplot/{celltype}_shuffled_top_snp.html', 'analysis'
+        f'plots/pvalues_qqplot/{celltype}_shuffled_top_snp.png', 'analysis'
     )
     hl.hadoop_copy('qqplot.png', gcs_path_p)
 

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+This script summarise SAIGE-QTL raw p-value results
+and plots QQ plots and histograms of the p-values
+
+To run:
+
+analysis-runner \
+    --description "plot p-values" \
+    --dataset "bioheart" \
+    --access-level "test" \
+    --output-dir "saige-qtl/" \
+    python3 summarise_and_qq_plotter.py \
+        --celltype='B_naive' \
+        --results-path=gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files \
+        --title='Shuffled p-values (SAIGE-QTL pipeline)'
+"""
+
+import click
+import pandas as pd
+from cpg_utils import to_path
+
+# import hail as hl
+
+# from cpg_utils.hail_batch import init_batch, output_path
+# from bokeh.plotting import output_file, save
+
+
+@click.command()
+@click.option('--celltype', required=True)
+@click.option('--results-path', required=True)
+# @click.option('--title', default='SAIGE-QTL pipeline p-values')
+def plot_pvalues(
+    celltype: str,
+    results_path: str,
+    # title: str,
+):
+    """
+    combines the results for a given cell type,
+    saving both all results and top SNP per gene results
+    plots both a histogram and a QQ plot of the association p-values
+    """
+    # init_batch()
+
+    # collect all raw p-value files
+    existing_cv_assoc_results = [
+        str(file) for file in to_path(results_path).glob(f'{celltype}_*_cis')
+    ]
+    # concatenates the dataframes using pandas
+    results_all_df = []
+    results_top_snp_df = []
+    for pv_df in existing_cv_assoc_results:
+        df = pd.read_csv(to_path(pv_df), sep='\t')
+        # add gene as column before merging
+        df['gene'] = (
+            pv_df.replace(f'{results_path}/', '')
+            .replace(f'{celltype}_', '')
+            .replace('_cis', '')
+        )
+        # add SNP info
+        df['is_snp'] = [
+            len(df['Allele1'].values[i]) == 1 and len(df['Allele2'].values[i]) == 1
+            for i in range(df.shape[0])
+        ]
+        results_all_df.append(df)
+        # select top SNP
+        df_snp = df[df['is_snp']]
+        df_top_snp = df_snp[df_snp['p.value'] == df_snp['p.value'].min()]
+        results_top_snp_df.append(df_top_snp)
+    results_all_df = pd.concat(results_all_df)
+    results_top_snp_df = pd.concat(results_top_snp_df)
+
+    # save
+    results_all_file = (
+        f'{results_path}/summary_stats/{celltype}_all_cis_raw_pvalues.tsv'
+    )
+    results_all_df.to_csv(results_all_file, sep='\t')
+
+    results_top_snp_file = (
+        f'{results_path}/summary_stats/{celltype}_top_snp_cis_raw_pvalues.tsv'
+    )
+    results_top_snp_df.to_csv(results_top_snp_file, sep='\t')
+
+    # p = hl.plot.histogram(mt.variant_qc.AF[1], legend=title)
+    # output_file('local_histo.html')
+    # save(p)
+    # gcs_path_p = output_path(f'plots/frequency_histo/{vds_name}.html', 'analysis')
+    # hl.hadoop_copy('local_histo.html', gcs_path_p)
+
+
+if __name__ == '__main__':
+    plot_pvalues()

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -23,9 +23,8 @@ import hail as hl
 import numpy as np
 import pandas as pd
 from cpg_utils import to_path
-from cpg_utils.hail_batch import output_path
+from cpg_utils.hail_batch import init_batch, output_path
 
-# from cpg_utils.hail_batch import init_batch, output_path
 # from bokeh.plotting import output_file, save
 
 
@@ -43,7 +42,7 @@ def plot_pvalues(
     saving both all results and top SNP per gene results
     plots both a histogram and a QQ plot of the association p-values
     """
-    # init_batch()
+    init_batch()
 
     # collect all raw p-value files
     existing_cv_assoc_results = [

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -85,11 +85,13 @@ def plot_pvalues(
 
     # plot histograms
     # all results
-    plt.figure(figsize=(8, 8))
-    fig, ax = plt.subplots(figsize=(8, 8))
-    ax.hist(results_all_df['p.value'])
-    # fig.tight_layout()
-    fig.savefig('histo.png')
+    # plt.figure(figsize=(8, 8))
+    # fig, ax = plt.subplots(figsize=(8, 8))
+    # ax.hist(results_all_df['p.value'])
+    # # fig.tight_layout()
+    # fig.savefig('histo.png')
+    plt.hist(results_all_df['p.value'])
+    plt.savefig('histo.png')
     gcs_path_p = output_path(
         f'plots/pvalues_histo/{celltype}_shuffled_all.html', 'analysis'
     )

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -19,6 +19,7 @@ analysis-runner \
 import click
 import matplotlib.pyplot as plt
 import hail as hl
+
 # import numpy as np
 import pandas as pd
 from cpg_utils import to_path

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -94,7 +94,7 @@ def plot_pvalues(
     #     low=0, high=1, size=results_top_snp_df.shape[0]
     # )
 
-    fig = plt.subplots(figsize=(10, 8))
+    fig, _ = plt.subplots(figsize=(10, 8))
     fig.save(p_hist_all)
     gcs_path_p = output_path(
         f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -83,17 +83,28 @@ def plot_pvalues(
     )
     results_top_snp_df.to_csv(results_top_snp_file, sep='\t')
 
-    # # plot histograms
-    # p_hist_all = plt.hist(results_all_df['p.value'])
-    # p_hist_top = plt.hist(results_top_snp_df['p.value'])
+    # plot histograms
+    # all results
+    plt.figure(figsize=(8, 8))
+    fig, ax = plt.subplots(figsize=(8, 8))
+    ax.hist(results_all_df['p.value'])
+    # fig.tight_layout()
+    fig.savefig('histo.png')
+    gcs_path_p = output_path(
+        f'plots/pvalues_histo/{celltype}_shuffled_all.html', 'analysis'
+    )
+    hl.hadoop_copy('histo.png', gcs_path_p)
 
-    # # save histograms
-    # fig, _ = plt.subplots(figsize=(10, 8))
-    # fig.save(p_hist_all)
-    # gcs_path_p = output_path(
-    #     f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
-    # )
-    # hl.hadoop_copy('local_histo.html', gcs_path_p)
+    # top SNP
+    plt.figure(figsize=(8, 8))
+    fig, ax = plt.subplots(figsize=(8, 8))
+    ax.hist(results_top_snp_df['p.value'])
+    # fig.tight_layout()
+    fig.savefig('histo.png')
+    gcs_path_p = output_path(
+        f'plots/pvalues_histo/{celltype}_shuffled_top_snp.html', 'analysis'
+    )
+    hl.hadoop_copy('histo.png', gcs_path_p)
 
     # QQ plots
     expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -84,39 +84,49 @@ def plot_pvalues(
     )
     results_top_snp_df.to_csv(results_top_snp_file, sep='\t')
 
-    # plot histograms
-    p_hist_all = plt.hist(results_all_df['p.value'])
-    p_hist_top = plt.hist(results_top_snp_df['p.value'])
+    # # plot histograms
+    # p_hist_all = plt.hist(results_all_df['p.value'])
+    # p_hist_top = plt.hist(results_top_snp_df['p.value'])
 
-    # save histograms
-    fig, _ = plt.subplots(figsize=(10, 8))
-    fig.save(p_hist_all)
-    gcs_path_p = output_path(
-        f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
-    )
-    hl.hadoop_copy('local_histo.html', gcs_path_p)
+    # # save histograms
+    # fig, _ = plt.subplots(figsize=(10, 8))
+    # fig.save(p_hist_all)
+    # gcs_path_p = output_path(
+    #     f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
+    # )
+    # hl.hadoop_copy('local_histo.html', gcs_path_p)
 
     # QQ plots
     expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])
-    expected_pvals_top = np.random.uniform(
-        low=0, high=1, size=results_top_snp_df.shape[0]
-    )
+    # expected_pvals_top = np.random.uniform(
+    #     low=0, high=1, size=results_top_snp_df.shape[0]
+    # )
     # all results
     x_all = -np.log10(np.sort(expected_pvals_all))
     y_all = -np.log10(np.sort(results_all_df['p.value']))
-    p_qq_all = plt.scatter(x_all, y_all)
-    # top SNP
-    x_top = -np.log10(np.sort(expected_pvals_top))
-    y_top = -np.log10(np.sort(results_top_snp_df['p.value']))
-    p_qq_top_snp = plt.scatter(x_top, y_top)
 
-    # save qq plots
-    fig, _ = plt.subplots(figsize=(10, 8))
-    fig.save(p_hist_all)
+    plt.figure(figsize=(8, 8))
+    fig, ax = plt.subplots(figsize=(8, 8))
+    ax.scatter(x_all, y_all)
+    fig.tight_layout()
+    fig.savefig('qqplot.png')
     gcs_path_p = output_path(
-        f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
+        f'plots/pvalues_qqplot/{celltype}_shuffled_all.html', 'analysis'
     )
-    hl.hadoop_copy('local_histo.html', gcs_path_p)
+    hl.hadoop_copy('qqplot.png', gcs_path_p)
+
+    # # top SNP
+    # x_top = -np.log10(np.sort(expected_pvals_top))
+    # y_top = -np.log10(np.sort(results_top_snp_df['p.value']))
+    # p_qq_top_snp = plt.scatter(x_top, y_top)
+
+    # # save qq plots
+
+    # fig.save(p_hist_all)
+    # gcs_path_p = output_path(
+    #     f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
+    # )
+    # hl.hadoop_copy('local_histo.html', gcs_path_p)
 
 
 if __name__ == '__main__':

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -19,7 +19,7 @@ analysis-runner \
 import click
 import matplotlib.pyplot as plt
 import hail as hl
-import numpy as np
+# import numpy as np
 import pandas as pd
 from cpg_utils import to_path
 from cpg_utils.hail_batch import output_path

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -12,8 +12,7 @@ analysis-runner \
     --output-dir "saige-qtl/" \
     python3 plotter/summarise_and_qq_plotter.py \
         --celltype='B_naive' \
-        --results-path=gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files \
-        --title='Shuffled p-values (SAIGE-QTL pipeline)'
+        --results-path=gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files
 """
 
 import click
@@ -25,17 +24,13 @@ import pandas as pd
 from cpg_utils import to_path
 from cpg_utils.hail_batch import init_batch, output_path
 
-# from bokeh.plotting import output_file, save
-
 
 @click.command()
 @click.option('--celltype', required=True)
 @click.option('--results-path', required=True)
-# @click.option('--title', default='SAIGE-QTL pipeline p-values')
 def plot_pvalues(
     celltype: str,
     results_path: str,
-    # title: str,
 ):
     """
     combines the results for a given cell type,
@@ -85,11 +80,6 @@ def plot_pvalues(
 
     # plot histograms
     # all results
-    # plt.figure(figsize=(8, 8))
-    # fig, ax = plt.subplots(figsize=(8, 8))
-    # ax.hist(results_all_df['p.value'])
-    # # fig.tight_layout()
-    # fig.savefig('histo.png')
     plt.hist(results_all_df['p.value'])
     plt.savefig('histo.png')
     gcs_path_p = output_path(
@@ -101,7 +91,6 @@ def plot_pvalues(
     plt.figure(figsize=(8, 8))
     fig, ax = plt.subplots(figsize=(8, 8))
     ax.hist(results_top_snp_df['p.value'])
-    # fig.tight_layout()
     fig.savefig('histo.png')
     gcs_path_p = output_path(
         f'plots/pvalues_histo/{celltype}_shuffled_top_snp.png', 'analysis'
@@ -117,7 +106,6 @@ def plot_pvalues(
     plt.figure(figsize=(8, 8))
     fig, ax = plt.subplots(figsize=(8, 8))
     ax.scatter(x_all, y_all)
-    # fig.tight_layout()
     fig.savefig('qqplot.png')
     gcs_path_p = output_path(
         f'plots/pvalues_qqplot/{celltype}_shuffled_all.png', 'analysis'
@@ -134,7 +122,6 @@ def plot_pvalues(
     plt.figure(figsize=(8, 8))
     fig, ax = plt.subplots(figsize=(8, 8))
     ax.scatter(x_top, y_top)
-    # fig.tight_layout()
     fig.savefig('qqplot.png')
     gcs_path_p = output_path(
         f'plots/pvalues_qqplot/{celltype}_shuffled_top_snp.png', 'analysis'

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -18,11 +18,11 @@ analysis-runner \
 
 import click
 import matplotlib.pyplot as plt
+import hail as hl
 import numpy as np
 import pandas as pd
 from cpg_utils import to_path
-
-# import hail as hl
+from cpg_utils.hail_batch import output_path
 
 # from cpg_utils.hail_batch import init_batch, output_path
 # from bokeh.plotting import output_file, save
@@ -85,19 +85,20 @@ def plot_pvalues(
 
     # plot histograms
     p_hist_all = plt.hist(results_all_df['p.value'])
-    p_hist_top = plt.hist(results_top_snp_df['p.value'])
+    # p_hist_top = plt.hist(results_top_snp_df['p.value'])
 
-    # QQ plots
-    expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])
-    expected_pvals_top = np.random.uniform(
-        low=0, high=1, size=results_top_snp_df.shape[0]
+    # # QQ plots
+    # expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])
+    # expected_pvals_top = np.random.uniform(
+    #     low=0, high=1, size=results_top_snp_df.shape[0]
+    # )
+
+    fig = plt.subplots(figsize=(10, 8))
+    fig.save(p_hist_all)
+    gcs_path_p = output_path(
+        f'plots/pvalues_histo/{celltype}_shuffled.html', 'analysis'
     )
-
-    # p = hl.plot.histogram(mt.variant_qc.AF[1], legend=title)
-    # output_file('local_histo.html')
-    # save(p)
-    # gcs_path_p = output_path(f'plots/frequency_histo/{vds_name}.html', 'analysis')
-    # hl.hadoop_copy('local_histo.html', gcs_path_p)
+    hl.hadoop_copy('local_histo.html', gcs_path_p)
 
 
 if __name__ == '__main__':

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -17,6 +17,8 @@ analysis-runner \
 """
 
 import click
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 from cpg_utils import to_path
 
@@ -47,8 +49,8 @@ def plot_pvalues(
         str(file) for file in to_path(results_path).glob(f'{celltype}_*_cis')
     ]
     # concatenates the dataframes using pandas
-    results_all_df = []
-    results_top_snp_df = []
+    results_all_df_list = []
+    results_top_snp_df_list = []
     for pv_df in existing_cv_assoc_results:
         df = pd.read_csv(to_path(pv_df), sep='\t')
         # add gene as column before merging
@@ -67,8 +69,8 @@ def plot_pvalues(
         df_snp = df[df['is_snp']]
         df_top_snp = df_snp[df_snp['p.value'] == df_snp['p.value'].min()]
         results_top_snp_df.append(df_top_snp)
-    results_all_df = pd.concat(results_all_df)
-    results_top_snp_df = pd.concat(results_top_snp_df)
+    results_all_df = pd.concat(results_all_df_list)
+    results_top_snp_df = pd.concat(results_top_snp_df_list)
 
     # save
     results_all_file = (
@@ -80,6 +82,16 @@ def plot_pvalues(
         f'{results_path}/summary_stats/{celltype}_top_snp_cis_raw_pvalues.tsv'
     )
     results_top_snp_df.to_csv(results_top_snp_file, sep='\t')
+
+    # plot histograms
+    p_hist_all = plt.hist(results_all_df['p.value'])
+    p_hist_top = plt.hist(results_top_snp_df['p.value'])
+
+    # QQ plots
+    expected_pvals_all = np.random.uniform(low=0, high=1, size=results_all_df.shape[0])
+    expected_pvals_top = np.random.uniform(
+        low=0, high=1, size=results_top_snp_df.shape[0]
+    )
 
     # p = hl.plot.histogram(mt.variant_qc.AF[1], legend=title)
     # output_file('local_histo.html')

--- a/plotter/summarise_and_qq_plotter.py
+++ b/plotter/summarise_and_qq_plotter.py
@@ -10,7 +10,7 @@ analysis-runner \
     --dataset "bioheart" \
     --access-level "test" \
     --output-dir "saige-qtl/" \
-    python3 summarise_and_qq_plotter.py \
+    python3 plotter/summarise_and_qq_plotter.py \
         --celltype='B_naive' \
         --results-path=gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files \
         --title='Shuffled p-values (SAIGE-QTL pipeline)'


### PR DESCRIPTION
This script combines the raw p-value files into two files (per cell type):

1. one containing all p-values for all SNPs tested and all genes
2. one containing only the top SNP for each gene

These files are different from the gene-level summary files (e.g. `cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files/summary_stats/B_naive_all_cis_cv_results.tsv`) which are post multiple testing correction (step 3 of the `saige_assoc.py` script).
Here, we extract the raw p-values (outputs of step 2) to check their distribution by plotting. This is especially useful for runs where we shuffled individual IDs and we want to check for calibration (i.e. we expect / hope for no inflation in the p-values in this scenario).

In this scenario, we expect p-values (under the null) to approximately follow a uniform distribution between 0 and 1, so no peak at 0 in the histogram, and a scatterplot along the diagonal in the QQ plot.

successfully ran in `test`: https://batch.hail.populationgenomics.org.au/batches/482994/jobs/1 🎉 output files:

- summary files: `cpg-bioheart-test-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/sample_perm0/output_files/summary_stats`
- histograms: `cpg-bioheart-test-analysis/saige-qtl/plots/pvalues_histo`
- QQplots: `cpg-bioheart-test-analysis/saige-qtl/plots/pvalues_qqplot`