### PR TITLE
remove $ sign

### DIFF
--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -158,7 +158,7 @@ def build_run_set_based_test_command(
         --chrom={chrom} \
         --GMMATmodelFile={gmmat_model_path} \
         --varianceRatioFile={variance_ratio_path} \
-        --groupFile=${group_file} \
+        --groupFile={group_file} \
         {args_from_config}
     """
     )


### PR DESCRIPTION
Not sure how the `$` sign ended up there 🤦‍♀️ 

there may be other issues but the [error](https://batch.hail.populationgenomics.org.au/batches/482945/jobs/3) was when looking for this file and this is an obvious difference between instances of dealing with the `cis_window_file` in `saige_assoc.py` (corresponding line: https://github.com/populationgenomics/saige-tenk10k/blob/main/saige_assoc.py#L158) vs the `group file` here.