### PR TITLE
group file should be tab separated

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -121,7 +121,7 @@ def main(
             group_vals_df = pd.merge(group_df, vals_df, on='category')
             group_file = f'{group_files_path}{chrom}/{gene}_{cis_window}bp.tsv'
             with to_path(group_file).open('w') as gdf:
-                group_vals_df.to_csv(gdf, index=False, header=False)
+                group_vals_df.to_csv(gdf, index=False, header=False, sep='\t')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I think the reason [this](https://batch.hail.populationgenomics.org.au/batches/483004/jobs/2) fails may be that group files should be tab separated, not comma.

See an [example group file](https://github.com/weizhou0/qtl/blob/main/extdata/input/groupFile_temp.txt) in the SAIGE-QTL repo.

On the plus side, step 1 was not re-run (as hoping) and step 2 does at least start, so the [dollar sign removal](https://github.com/populationgenomics/saige-tenk10k/pull/122) was useful!