### PR TITLE
Modify SAIGE-QTL RV flags / args for debugging

### DIFF
--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -322,6 +322,7 @@ def summarise_cv_results(
     '--vre-files-prefix', default=dataset_path('saige-qtl/input_files/genotypes')
 )
 @click.option('--ngenes-to-test', default='all')
+@click.option('--group-file-specs', default='')
 @click.command()
 def main(
     # output from get_anndata.py
@@ -332,6 +333,7 @@ def main(
     genotype_files_prefix: str,
     vre_files_prefix: str,
     ngenes_to_test: str,
+    group_file_specs: str,
 ):
     """
     Run SAIGE-QTL RV pipeline for all cell types
@@ -394,7 +396,7 @@ def main(
                 pheno_cov_path = (
                     f'{pheno_cov_files_path_ct_chrom}/{gene}_{celltype}_pheno_cov.tsv'
                 )
-                group_path = f'{group_files_path_chrom}/{gene}_{cis_window_size}bp.tsv'
+                group_path = f'{group_files_path_chrom}/{gene}_{cis_window_size}bp{group_file_specs}.tsv'
 
                 gene_dependency = get_batch().new_job(f' Always run job for {gene}')
                 gene_dependency.always_run()

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -383,6 +383,7 @@ def main(
             drop_genes: list[str] = get_config()['saige']['drop_genes']
 
             genes = [x for x in genes if x not in drop_genes]
+            genes = genes[0:2]
 
             # extract relevant gene-related files
             for gene in genes:

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -321,6 +321,7 @@ def summarise_cv_results(
 @click.option(
     '--vre-files-prefix', default=dataset_path('saige-qtl/input_files/genotypes')
 )
+@click.option('--ngenes-to-test', default='all')
 @click.command()
 def main(
     # output from get_anndata.py
@@ -330,6 +331,7 @@ def main(
     # outputs from get_genotype_vcf.py
     genotype_files_prefix: str,
     vre_files_prefix: str,
+    ngenes_to_test: str,
 ):
     """
     Run SAIGE-QTL RV pipeline for all cell types
@@ -375,6 +377,9 @@ def main(
                     f'*_{celltype}_pheno_cov.tsv'
                 )
             ]
+            # if specified, only test ngenes genes
+            if ngenes_to_test != 'all':
+                files = files[0 : int(ngenes_to_test)]
             logging.info(f'I found these files: {", ".join(files)}')
 
             genes = [f.replace(f'_{celltype}_pheno_cov.tsv', '') for f in files]
@@ -383,7 +388,6 @@ def main(
             drop_genes: list[str] = get_config()['saige']['drop_genes']
 
             genes = [x for x in genes if x not in drop_genes]
-            genes = genes[0:2]
 
             # extract relevant gene-related files
             for gene in genes:

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -43,6 +43,7 @@ LOCO = 'FALSE'
 markers_per_chunk = 10000
 SPAcutoff = 10000
 [saige.set_test]
+vcfField = 'GT'
 maxMAF_in_groupTest = 0.1
 minMAF_in_groupTest_Exclude = 0
 annotation_in_groupTest = 'null'


### PR DESCRIPTION
The rare variant set-test run is costing a lot more than expected: https://batch.hail.populationgenomics.org.au/batches/483008 😬 

A couple of changes to debug:
* noticing that `GT` was specified as VCF field for single-variant tests, vs `DS`
* added an argument to specify how many genes are tested `--ngenes-to-test`, so can be run for just one or two genes when debugging
* because the stalling happened when specifying the weights, add option to specify different group file names (e.g. `_no_weights` as generated here: https://github.com/populationgenomics/saige-tenk10k/pull/125, but in the future specify annotations etc)

[Slack thread](https://centrepopgen.slack.com/archives/C030X7WGFCL/p1725919664235749) for some context.