### PR TITLE
weights as option in group file

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -44,7 +44,7 @@ from cpg_utils.hail_batch import init_batch
 @click.option('--group-files-path')
 @click.option('--vcf-path')
 @click.option('--cis-window', default=100000)
-@click.option('--gamma', default=1e-5)
+@click.option('--gamma', default='1e-5')
 @click.option('--ngenes-to-test', default='all')
 @click.option('--genome-reference', default='GRCh37')
 def main(
@@ -53,7 +53,7 @@ def main(
     group_files_path: str,
     vcf_path: str,
     cis_window: int,
-    gamma: float,
+    gamma: str,
     ngenes_to_test: str,
     genome_reference: str,
 ):
@@ -112,7 +112,7 @@ def main(
                 # the distance of that variant from the gene
                 # Following the approach used by the APEX authors
                 # doi: https://doi.org/10.1101/2020.12.18.423490
-                weights = [math.exp(-gamma * abs(d)) for d in distances]
+                weights = [math.exp(-float(gamma) * abs(d)) for d in distances]
                 group_df = pd.DataFrame(
                     {
                         'gene': [gene, gene, gene],

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -103,7 +103,16 @@ def main(
             ds_result = hl.filter_intervals(
                 ds, [hl.parse_locus_interval(gene_interval, reference_genome='GRCh37')]
             )
-            variants = [loc.position for loc in ds_result.locus.collect()]
+            variants_chrom_pos = [
+                f'{loc.contig}_{loc.position}' for loc in ds_result.locus.collect()
+            ]
+            variants_alleles = [
+                f'{allele[0]}_{allele[1]}' for allele in ds_result.alleles.collect()
+            ]
+            variants = [
+                f'{variants_chrom_pos[i]}_{variants_alleles[i]}'
+                for i in range(len(variants_chrom_pos))
+            ]
 
             if gamma != 'none':
                 gene_tss = int(window_start) + cis_window

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -138,7 +138,7 @@ def main(
             group_vals_df = pd.merge(group_df, vals_df, on='category')
 
             with to_path(group_file).open('w') as gdf:
-                group_vals_df.to_csv(gdf, index=False, header=False, sep='\t')
+                group_vals_df.to_csv(gdf, index=False, sep='\t')
 
 
 if __name__ == '__main__':

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -105,7 +105,7 @@ def main(
             )
             variants = [loc.position for loc in ds_result.locus.collect()]
 
-            if gamma is not None:
+            if gamma != 'none':
                 gene_tss = int(window_start) + cis_window
                 distances = [int(var) - gene_tss for var in variants]
                 # get weight for genetic variants based on

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -147,7 +147,7 @@ def main(
             group_vals_df = pd.merge(group_df, vals_df, on='category')
 
             with to_path(group_file).open('w') as gdf:
-                group_vals_df.to_csv(gdf, index=False, sep='\t')
+                group_vals_df.to_csv(gdf, index=False, header=False, sep='\t')
 
 
 if __name__ == '__main__':

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -104,13 +104,13 @@ def main(
                 ds, [hl.parse_locus_interval(gene_interval, reference_genome='GRCh37')]
             )
             variants_chrom_pos = [
-                f'{loc.contig}_{loc.position}' for loc in ds_result.locus.collect()
+                f'{loc.contig}:{loc.position}' for loc in ds_result.locus.collect()
             ]
             variants_alleles = [
-                f'{allele[0]}_{allele[1]}' for allele in ds_result.alleles.collect()
+                f'{allele[0]}:{allele[1]}' for allele in ds_result.alleles.collect()
             ]
             variants = [
-                f'{variants_chrom_pos[i]}_{variants_alleles[i]}'
+                f'{variants_chrom_pos[i]}:{variants_alleles[i]}'
                 for i in range(len(variants_chrom_pos))
             ]
 

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -104,7 +104,7 @@ def main(
                 ds, [hl.parse_locus_interval(gene_interval, reference_genome='GRCh37')]
             )
             variants = [loc.position for loc in ds_result.locus.collect()]
-            
+
             if gamma is not None:
                 gene_tss = int(window_start) + cis_window
                 distances = [int(var) - gene_tss for var in variants]


### PR DESCRIPTION
Updated version of https://github.com/populationgenomics/saige-tenk10k/pull/125 to keep more general: have `gamma` as an arg such that we can provide a value if we want to include dTSS weights, or `none` if not.

Ran successfully when 
* including weights (default `gamma`): https://batch.hail.populationgenomics.org.au/batches/483314/jobs/1 (files here: `cpg-bioheart-test/saige-qtl/input_files/group_files/v2/chr22`)
* excluding weights (setting `gamma` = `none`): https://batch.hail.populationgenomics.org.au/batches/483312/jobs/1 (files also here: `cpg-bioheart-test/saige-qtl/input_files/group_files/v2/chr22`, this time with `no_weights` in the name)

Additionally, updating variant definition to match format from the [SAIGE-QTL example group file](https://github.com/weizhou0/qtl/blob/main/extdata/input/nfam_500_nindep_5000_01_group.txt), i.e. `chrom.pos.ref.alt`
