### PR TITLE
space separated instead of tab

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -147,7 +147,7 @@ def main(
             group_vals_df = pd.merge(group_df, vals_df, on='category')
 
             with to_path(group_file).open('w') as gdf:
-                group_vals_df.to_csv(gdf, index=False, header=False, sep='\t')
+                group_vals_df.to_csv(gdf, index=False, header=False, sep=' ')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Very conscious that this all feels like trial and error without much reasoning behind it, but Wei suggested saving the group file as space-separated instead of tab to get around the error when running the SAIGE-QTL RV pipeline, so trying this here.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1725919664235749