### PR TITLE
Update variant format groupfile

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -147,7 +147,7 @@ def main(
             group_vals_df = pd.merge(group_df, vals_df, on='category')
 
             with to_path(group_file).open('w') as gdf:
-                group_vals_df.to_csv(gdf, index=False, header=False, sep='\t')
+                group_vals_df.to_csv(gdf, index=False, header=False, sep=' ')
 
 
 if __name__ == '__main__':

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -107,10 +107,10 @@ def main(
                 f'{loc.contig}:{loc.position}' for loc in ds_result.locus.collect()
             ]
             variants_alleles = [
-                f'{allele[0]}:{allele[1]}' for allele in ds_result.alleles.collect()
+                f'{allele[0]}/{allele[1]}' for allele in ds_result.alleles.collect()
             ]
             variants = [
-                f'{variants_chrom_pos[i]}:{variants_alleles[i]}'
+                f'{variants_chrom_pos[i]}_{variants_alleles[i]}'
                 for i in range(len(variants_chrom_pos))
             ]
 
@@ -147,7 +147,7 @@ def main(
             group_vals_df = pd.merge(group_df, vals_df, on='category')
 
             with to_path(group_file).open('w') as gdf:
-                group_vals_df.to_csv(gdf, index=False, header=False, sep=' ')
+                group_vals_df.to_csv(gdf, index=False, header=False, sep='\t')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
update to `chr:pos_ref/alt` based on code def ([script](https://github.com/weizhou0/qtl/blob/aaaadeba8748aecebc1268252567216a1272c59a/extdata/step2_tests_qtl.R)):

> make_option("--groupFile",
    type = "character", default = "",
    help = "Path to the file containing the group information for gene-based tests. Each gene/set has 2 or 3 lines in the group file. The first element is the gene/set name. The second element in the first line is to indicate whether this line contains variant IDs (var), annotations (anno), or weights (weight). The line for weights is optional. If not specified, the default weights will be generated based on beta(MAF, 1, 25). Use --weights.beta to change the parameters for the Beta distribution. The variant ids must be in the format chr:pos_ref/alt. Elements are seperated by tab or space."
  )
  
 