### PR TITLE
only take var pos for distances

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -101,7 +101,12 @@ def main(
             gene_interval = f'{num_chrom}:{window_start}-{window_end}'
             # extract variants within interval
             ds_result = hl.filter_intervals(
-                ds, [hl.parse_locus_interval(gene_interval, reference_genome='GRCh37')]
+                ds,
+                [
+                    hl.parse_locus_interval(
+                        gene_interval, reference_genome=genome_reference
+                    )
+                ],
             )
             variants_chrom_pos = [
                 f'{loc.contig}:{loc.position}' for loc in ds_result.locus.collect()
@@ -118,7 +123,7 @@ def main(
 
             if gamma != 'none':
                 gene_tss = int(window_start) + cis_window
-                distances = [int(var) - gene_tss for var in variants]
+                distances = [int(var.split(":")[1]) - gene_tss for var in variants]
                 # get weight for genetic variants based on
                 # the distance of that variant from the gene
                 # Following the approach used by the APEX authors


### PR DESCRIPTION
Last run [failed](https://batch.hail.populationgenomics.org.au/batches/483632/jobs/1) because we changed the variant ids to not be just numerical.
Extracting numerical part of variant, i.e. the position from `chr:pos:ref:alt`

Syntax tested in a notebook:

<img width="581" alt="Screenshot 2024-09-13 at 2 31 17 PM" src="https://github.com/user-attachments/assets/5ae409de-f92d-40a7-b939-40e9c339fe95">

Then I also noticed the genome reference wasn't used as an arg where it should be so, fixing that here too.