### PR TITLE
Update instructions at top of scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Outputs:
 * VCF files containing all retained rare variants (one per chromosome) + corresponding index files (`.csi`)
 * plink object for only 2,000 variants (minor allele count > 20), after LD pruning - this is for the estimation of the variance ratio (VRE plink files)
 
-### Notes
+### Notes (get_genotype_vcf.py)
 
 SAIGE-QTL allows numeric chromosomes only, so both the .bim and the VCF files are modified in this script to remove the 'chr' notation (so that e.g., 'chr1' becomes '1').
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Outputs:
 * if set to true, single-variant test raw p-values for all variants in the group also (one per gene, cell type)
 * set-based association summary statistics (gene-level p-values summarised, one per cell type)
 
-### SAIGE-QTL parameters explanation
+## SAIGE-QTL parameters explanation
 
 Clarifying the reasoning behind the parameters / flags used to run SAIGE-QTL.
 Most of these are (or will be) included in the official [documentation](https://weizhou0.github.io/SAIGE-QTL-doc/).

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Briefly, if one wanted to run both common and rare variant pipelines, the order 
 2. get_sample_covariates.py (does not require any other part of the pipeline and can be run in parallel with 1)
 3. get_anndata.py (requires 2)
 4. saige_assoc.py (requires 1,3)
-5. make_group_file.py (requires 1,3)
+5. make_group_file.py (requires 1,3 and can be run in parallel with 4)
 6. saige_assoc_set_test.py (requires 1,3,4 (so that step1 is only run once) and 5)
 
 ## Data

--- a/get_anndata.py
+++ b/get_anndata.py
@@ -4,31 +4,26 @@
 This script will
 
 - open anndata expression files
-- open covariate files
+- open cell and samples covariate files
 - create pheno_cov_files
 - create cis window files
 
 these files will be used as inputs for the
-SAIGE-QTL association pipeline.
+SAIGE-QTL association pipelines (both common and rare).
 
 To run:
 
-In main:
-
-In test:
-
 analysis-runner \
-    --description "make expression input files" \
-    --dataset "bioheart" \
-    --access-level "test" \
-    --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/input_files" \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
-    python3 get_anndata.py --celltypes B_naive --chromosomes chr21 \
-    --anndata-files-prefix gs://cpg-bioheart-test/saige-qtl/anndata_objects_from_HPC \
-    --celltype-covs-files-prefix gs://cpg-bioheart-test/saige-qtl/celltype_covs_from_HPC \
-    --sample-covs-file gs://cpg-bioheart-test-analysis/saige-qtl/input_files/covariates/sex_age_geno_pcs_shuffled_ids_tob_bioheart.csv \
-    --concurrent-job-cap=1000 --pc-job-cpu=1 --cis-job-cpu=1
-
+   --description "make expression input files" \
+   --dataset "bioheart" \
+   --access-level "full" \
+   --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920" \
+   --image australia-southeast1-docker.pkg.dev/cpg-common/images/scanpy:1.9.3 \
+   python3 get_anndata.py --celltypes B_naive --chromosomes chr2 \
+   --anndata-files-prefix gs://cpg-bioheart-main/saige-qtl/240-libraries/anndata_objects_from_HPC \
+   --celltype-covs-files-prefix gs://cpg-bioheart-main/saige-qtl/240-libraries/celltype_covs_from_HPC \
+   --sample-covs-file gs://cpg-bioheart-main-analysis/saige-qtl/input_files/240920/covariates/sex_age_geno_pcs_shuffled_ids_tob_bioheart.csv \
+   --pc-job-mem=8G
 
 """
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -12,36 +12,12 @@ for variance ratio estimation
 this will be used as input for the
 SAIGE-QTL association pipeline.
 
-
-To run:
-
-In test:
-
 analysis-runner \
-    --description "get common variant VCF" \
-    --dataset "bioheart" \
-    --access-level "test" \
-    --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/input_files/genotypes/v3" \
-    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-test/vds/tenk10k1-0.vds --chromosomes chr21 \
-        --cv-maf-threshold 0 --rv-maf-threshold 1 --vre-mac-threshold 1 --vre-n-markers 5
-
-In main:
-
-analysis-runner \
-    --description "get common and rare variant VCFs" \
-    --dataset "bioheart" \
-    --access-level "full" \
-    --output-dir "saige-qtl/input_files/genotypes/" \
-    python3 get_genotype_vcf.py --vds-path=gs:// --chromosomes chr1,chr2,chr22
-
-
-    analysis-runner \
    --description "get common and rare variant VCFs" \
-   --dataset "tob-wgs" \
+   --dataset "bioheart" \
    --access-level "full" \
-   --output-dir "saige-qtl/tob_n1055/input_files/genotypes/" \
-   python3 get_genotype_vcf.py --vds-path=gs://cpg-tob-wgs-main/vds/tob-wgs1-0.vds --chromosomes chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22
-
+   --output-dir saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/genotypes/ \
+    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-main/vds/tenk10k1-0.vds --chromosomes chr2
 
 """
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -15,9 +15,10 @@ SAIGE-QTL association pipeline.
 analysis-runner \
    --description "get common and rare variant VCFs" \
    --dataset "bioheart" \
-   --access-level "full" \
+   --access-level "standard" \
    --output-dir saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/genotypes/ \
-    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-main/vds/tenk10k1-0.vds --chromosomes chr2
+    python3 get_genotype_vcf.py --vds-path=gs://cpg-bioheart-main/vds/tenk10k1-0.vds --chromosomes chr2 \
+    --relateds-to-drop-path=gs://cpg-bioheart-main-analysis/large_cohort/bioheart1-0/relateds_to_drop.ht
 
 """
 
@@ -183,6 +184,10 @@ def remove_chr_from_bim(input_bim: str, output_bim: str, bim_renamed: str):
 # inputs:
 @click.option('--vds-path', help=' GCP gs:// path to the VDS')
 @click.option('--chromosomes', help=' e.g., chr22,chrX ')
+@click.option(
+    '--relateds-to-drop-path',
+    default='gs://cpg-bioheart-main-analysis/large_cohort/bioheart1-0/relateds_to_drop.ht',
+)
 @click.option('--cv-maf-threshold', default=0.01)
 @click.option('--rv-maf-threshold', default=0.01)
 @click.option('--vre-mac-threshold', default=20)
@@ -190,14 +195,11 @@ def remove_chr_from_bim(input_bim: str, output_bim: str, bim_renamed: str):
 @click.option('--exclude-multiallelic', is_flag=False)
 @click.option('--exclude-indels', is_flag=False)
 @click.option('--plink-job-storage', default='1G')
-@click.option(
-    '--relateds-to-drop-path',
-    default='gs://cpg-bioheart-test/large_cohort/v1-0/relateds_to_drop.ht',
-)
 @click.command()
 def main(
     vds_path: str,
     chromosomes: str,
+    relateds_to_drop_path: str,
     cv_maf_threshold: float,
     rv_maf_threshold: float,
     vre_mac_threshold: int,
@@ -205,7 +207,6 @@ def main(
     exclude_multiallelic: bool,
     exclude_indels: bool,
     plink_job_storage: str,
-    relateds_to_drop_path: str,
 ):
     """
     Write genotypes as VCF

--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -15,27 +15,14 @@ building inputs for the SAIGE-QTL association pipeline.
 
 To run,
 
-in test:
-
 analysis-runner \
     --description "get sample covariates" \
     --dataset "bioheart" \
-    --access-level "test" \
-    --output-dir "saige-qtl/input_files/covariates/" \
-    python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-bioheart-test/saige-qtl/input_files/mapping_for_anna.csv' \
-                --bioheart-sex-file-path 'gs://cpg-bioheart-test-analysis/hoptan-str/somalier/somalier.samples.tsv' \
-                --project-names 'tob-wgs,bioheart' --vds-version tenk10k1-0
-
-in main:
-
-analysis-runner \
-    --description "get sample covariates" \
-    --dataset "bioheart" \
-    --access-level "standard" \
-    --output-dir "saige-qtl/input_files/covariates/" \
-    python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-bioheart-test/saige-qtl/input_files/mapping_for_anna.csv' \
-                --bioheart-sex-file-path 'gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv' \
-                --project-names 'tob-wgs,bioheart' --vds-version v1-0
+    --access-level "full" \
+    --output-dir "saige-qtl/input_files/240920/covariates" \
+        python3 get_sample_covariates.py --tob-sex-file-path 'gs://cpg-bioheart-test/saige-qtl/input_files/mapping_for_anna.csv' \
+            --bioheart-sex-file-path 'gs://cpg-bioheart-main-analysis/qc-stand-alone/somalier/990_samples_somalier.samples.tsv' \
+            --project-names 'tob-wgs,bioheart' --vds-version tenk10k1-0
 
 """
 

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -15,7 +15,7 @@ To run:
 analysis-runner \
    --description "make variant group input files" \
    --dataset "bioheart" \
-   --access-level "full" \
+   --access-level "standard" \
    --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920" \
    python3 make_group_file.py --chromosomes chr2 \
        --cis-window-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/cis_window_files/ \

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -13,16 +13,14 @@ SAIGE-QTL association pipeline.
 To run:
 
 analysis-runner \
-    --description "make variant group input files" \
-    --dataset "bioheart" \
-    --access-level "test" \
-    --output-dir "saige-qtl/input_files/" \
-    python3 make_group_file.py --chromosomes chr22 \
-        --cis-window-files-path gs://cpg-bioheart-test/saige-qtl/input_files/cis_window_files/ \
-        --group-files-path gs://cpg-bioheart-test/saige-qtl/input_files/group_files/ \
-        --vcf-path gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/input_files/genotypes/v3/vds-bioheart1-0 \
-        --ngenes-to-test 5
-
+   --description "make variant group input files" \
+   --dataset "bioheart" \
+   --access-level "full" \
+   --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920" \
+   python3 make_group_file.py --chromosomes chr2 \
+       --cis-window-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/cis_window_files/ \
+       --group-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/group_files/ \
+       --vcf-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/genotypes/vds-tenk10k1-0
 
 """
 

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -10,45 +10,24 @@ Hail Batch workflow to perform association tests using SAIGE-QTL
     - genotype file (from get_genotype_vcf.py)
     - VRE genotypes (from get_genotype_vcf.py)
 - builds saige commands (just add to str)
-- run SAIGE-QTL (execute Rscript from command line)
-- aggregate & summarise results (not yet)
+- run single-variant test using SAIGE-QTL (execute Rscript from command line)
+- aggregate & summarise results
 
 
 To run:
 
-In test:
-
 analysis-runner \
-    --config saige_assoc_test.toml \
-    --description "SAIGE-QTL association pipeline" \
-    --memory='32G' \
-    --storage='50G' \
-    --dataset "bioheart" \
-    --access-level "test" \
-    --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/v1" \
-     python3 saige_assoc.py \
-     --pheno-cov-files-path=gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/input_files/pheno_cov_files \
-        --cis-window-files-path=gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/input_files/cis_window_files \
-        --genotype-files-prefix=gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/input_files/genotypes/v3/vds-tenk10k1-0 \
-        --vre-files-prefix=gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/input_files/genotypes/v3/vds-tenk10k1-0
-
-
-In main:
-
-analysis-runner \
-    --config saige_assoc_test.toml \
-    --description "SAIGE-QTL association pipeline" \
-    --memory='32G' \
-    --storage='50G' \
-    --dataset "bioheart" \
-    --access-level "full" \
-    --output-dir "saige-qtl/bioheart_n990/v1" \
-     python3 saige_assoc.py \
-     --pheno-cov-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/v1/pheno_cov_files \
-        --cis-window-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/v1/cis_window_files \
-        --genotype-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/vds-bioheart1-0 \
-        --vre-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/vds-bioheart1-0
-
+   --config saige_assoc_test.toml \
+   --description "SAIGE-QTL CV association pipeline" \
+   --memory='32G' \
+   --storage='50G' \
+   --dataset "bioheart" \
+   --access-level "full" \
+   --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/output_files/240920" \
+    python3 saige_assoc.py  --pheno-cov-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/pheno_cov_files \
+       --cis-window-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/cis_window_files \
+       --genotype-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/genotypes/vds-tenk10k1-0 \
+       --vre-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/genotypes/vds-tenk10k1-0
 
 """
 

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -13,29 +13,26 @@ typically used for rare variants
     - VRE genotypes (from get_genotype_vcf.py)
     - group file (from make_group_file.py)
 - builds saige commands (just add to str)
-- run SAIGE-QTL (execute Rscript from command line)
+- run set-based tests using SAIGE-QTL (execute Rscript from command line)
 - aggregate & summarise results
 
 
 To run:
 
-Main:
-
 analysis-runner \
-    --config saige_assoc_test.toml \
-    --description "SAIGE-QTL RV association pipeline" \
-    --memory='32G' \
-    --storage='50G' \
-    --dataset "bioheart" \
-    --access-level "full" \
-    --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/v1" \
-     python3 saige_assoc_set_test.py \
-     --pheno-cov-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/pheno_cov_files \
-        --group-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/group_files \
-        --genotype-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/v4/vds-tenk10k1-0 \
-        --vre-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990/input_files/genotypes/v4/vds-tenk10k1-0 \
-        --group-file-specs _dTSS_weights
-
+   --config saige_assoc_test.toml \
+   --description "SAIGE-QTL RV association pipeline" \
+   --memory='32G' \
+   --storage='50G' \
+   --dataset "bioheart" \
+   --access-level "full" \
+   --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/output_files/240920" \
+    python3 saige_assoc_set_test.py \
+    --pheno-cov-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/pheno_cov_files \
+       --group-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/group_files \
+       --genotype-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/genotypes/vds-tenk10k1-0 \
+       --vre-files-prefix=gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/input_files/240920/genotypes/vds-tenk10k1-0 \
+       --group-file-specs _dTSS_weights
 
 """
 

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -2,7 +2,7 @@
 # principal arguments
 celltypes = ['B_naive']
 chromosomes = ['chr2']
-drop_genes =[]
+drop_genes =['ENSG00000115355','ENSG00000197585','ENSG00000228262','ENSG00000231969','ENSG00000289474','ENSG00000291127']
 
 # secondary arguments
 max_parallel_jobs = 350

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -59,7 +59,7 @@ storage = "0G"
 memory = "4Gi"
 [saige.job_specs.sv_test]
 cpu = 1
-storage = '12G'
+storage = '25G'
 [saige.job_specs.set_test]
 cpu = 1
 storage = '12G'

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -62,4 +62,4 @@ cpu = 1
 storage = '25G'
 [saige.job_specs.set_test]
 cpu = 1
-storage = '25G'
+storage = '30G'

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -62,4 +62,4 @@ cpu = 1
 storage = '25G'
 [saige.job_specs.set_test]
 cpu = 1
-storage = '12G'
+storage = '25G'

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,7 +1,7 @@
 [saige]
 # principal arguments
 celltypes = ['B_naive']
-chromosomes = ['chr22']
+chromosomes = ['chr2']
 drop_genes =[]
 
 # secondary arguments


### PR DESCRIPTION
Update running instructions at the top of each script to some that definitely work, as just tested (tested for the 971 genes on chr2, cell type: B naive):

- `get_genotype_vcf.py`: [batch 483831](https://batch.hail.populationgenomics.org.au/batches/483831) 🎉 
- `get_sample_covariates.py`: [batch 483833](https://batch.hail.populationgenomics.org.au/batches/483833) 🎉 
- `get_anndata.py`: [batch 483841](https://batch.hail.populationgenomics.org.au/batches/483841) 🎉 
- `saige_assoc.py`: [batch 483877](https://batch.hail.populationgenomics.org.au/batches/483877) (default max iter PCG: 500, storage: 25GB)
  - follow up for the 9 genes that failed to converge, increasing max iter PCG to 5,000 (see https://github.com/populationgenomics/saige-tenk10k/pull/118): [batch 483926](https://batch.hail.populationgenomics.org.au/batches/483926)) 
  - still only succeeded for 3 genes, trying again with max iter PCG 10,000 👀 : [batch 484401](https://batch.hail.populationgenomics.org.au/batches/484401)
  - all 6 still failed, trying one last time with max iter PCG 50,000: [batch 485276](https://batch.hail.populationgenomics.org.au/batches/485276) (fail again, drop for now)
  - running with those 6 genes skipped, just so the summarising step will run: [batch 485325](https://batch.hail.populationgenomics.org.au/batches/485325)  🎉
- `make_group_file.py`: [batch 483881](https://batch.hail.populationgenomics.org.au/batches/483881) 
  - cancelled and re-running post parallelisation (https://github.com/populationgenomics/saige-tenk10k/pull/146): [batch 484396](https://batch.hail.populationgenomics.org.au/batches/484396)
  - 3 jobs failed with a weird Hail error and 11 were cancelled as a consequence of those failures + max concurrency, so running again to resolve those: [batch 485260](https://batch.hail.populationgenomics.org.au/batches/485260) 🎉 
- `saige_assoc_set_test.py`: [batch 485300](https://batch.hail.populationgenomics.org.au/batches/485300) (storage: 30GB)
  - tries to run step 1 for the 6 failures above, still fails (solution for now add to [drop gene in the config](https://github.com/populationgenomics/saige-tenk10k/blob/main/saige_assoc_test.toml#L5))
  - cancelled because it was costing a lot to open the files? Running again after Matt's efficiency improvement (see https://github.com/populationgenomics/saige-tenk10k/pull/147): [batch 485308](https://batch.hail.populationgenomics.org.au/batches/485308) 
  - final run removing those 6 failed genes, just so the summarising step will run: [batch 485323](https://batch.hail.populationgenomics.org.au/batches/485323)  🎉

Pipeline (both single variant and test set tests) ran from end-to-end, with final results at: `cpg-bioheart-main-analysis/saige-qtl/bioheart_n990_and_tob_n1055/output_files/240920/summary_stats` 😍 
 