### PR TITLE
Peak efficiency

### DIFF
--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -96,7 +96,7 @@ def build_fit_null_command(
 # Run set-based association (step 2b)
 def build_run_set_based_test_command(
     set_output_path: str,
-    vcf_file: str,
+    vcf_group: hb.ResourceGroup,
     chrom: str,
     group_file: str,
     gmmat_model_path: str,
@@ -107,7 +107,7 @@ def build_run_set_based_test_command(
     This will run a single variant test using a score test
 
     Input:
-    - vcf file: path to VCF file
+    - vcf group: VCF & index file ResourceGroup
     - set test output path: path to output saige file
     - chrom: chromosome to run this on
     - group file: file with variants to test, and weights
@@ -121,7 +121,6 @@ def build_run_set_based_test_command(
     if to_path(set_output_path).exists():
         return None, get_batch().read_input(set_output_path)
 
-    vcf_group = get_batch().read_input_group(vcf=vcf_file, index=f'{vcf_file}.csi')
     group_file = get_batch().read_input(group_file)
 
     second_job = get_batch().new_job(name="saige-qtl part 2b")
@@ -310,6 +309,8 @@ def main(
     for chromosome in chromosomes:
         # genotype vcf files are one per chromosome
         vcf_file_path = f'{genotype_files_prefix}/{chromosome}_rare_variants.vcf.bgz'
+        vcf_group = get_batch().read_input_group(vcf=vcf_file_path, index=f'{vcf_file_path}.csi')
+
         # group files are split by gene but organised by chromosome also
         group_files_path_chrom = f'{group_files_path}/{chromosome}'
 
@@ -370,7 +371,7 @@ def main(
                     continue
                 step2_job = build_run_set_based_test_command(
                     set_output_path=set_output_path,
-                    vcf_file=vcf_file_path,
+                    vcf_group=vcf_group,
                     chrom=(chromosome[3:]),
                     group_file=group_path,
                     gmmat_model_path=null_output['rda'],

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -329,7 +329,9 @@ def main(
         jobs_in_vm = 0
         # genotype vcf files are one per chromosome, so read in at the top
         vcf_file_path = f'{genotype_files_prefix}/{chromosome}_rare_variants.vcf.bgz'
-        vcf_group = get_batch().read_input_group(vcf=vcf_file_path, index=f'{vcf_file_path}.csi')
+        vcf_group = get_batch().read_input_group(
+            vcf=vcf_file_path, index=f'{vcf_file_path}.csi'
+        )
 
         # group files are split by gene but organised by chromosome also
         group_files_path_chrom = f'{group_files_path}/{chromosome}'
@@ -389,9 +391,12 @@ def main(
                 set_key = f'{celltype}/{chromosome}/{celltype}_{gene}_cis_set'
                 # unique output path for this set-based test
                 set_output_path = output_path(set_key, 'analysis')
+
                 # if the output exists, do nothing
                 if to_path(set_output_path).exists():
                     continue
+
+                # instruct an additional command to run inside this VM
                 build_run_set_based_test_command(
                     job=step2_job,
                     set_key=set_key,

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -109,7 +109,8 @@ def build_run_set_based_test_command(
     This will run a single variant test using a score test
 
     Input:
-    - step2_job: job to run this command in
+    - job: job to run this command in
+    - set_key: unique key for this set-based test (used to name output)
     - vcf group: VCF & index file ResourceGroup
     - set test output path: path to output saige file
     - chrom: chromosome to run this on

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -419,6 +419,7 @@ def main(
                 # check if we need a new VM, i.e. we've hit the jobs-per-VM limit
                 if jobs_in_vm >= jobs_per_vm:
                     step2_job = create_a_2b_job()
+                    jobs_in_vm = 0
 
     # summarise results (per cell type)
     for celltype in celltypes:


### PR DESCRIPTION
There's a chance this approach is much more resource efficient
There's also a chance it doesn't work at all

Changes: 

1. Instead of creating one 'part 2b' job per gene, we create once per Chromosome
2. we set a number `jobs_per_vm` representing the max number of jobs we try to run per image, and `jobs_in_vm` as a counter of the number of commands stacked inside the current VM
3. `build_run_set_based_test_command` now takes a job and a chromosome VCF as arguments, and adds an additional command
4. the output per gene/celltype is written to a unique local path, then moved to a unique resource group path (this... might not be necessary. I expect writing to `job.output` multiple times in a loop would go wrong, so I'm making a unique path each time)
5. After a new job has been added, we check if there are too many jobs in that VM - if so, create a new job