### PR TITLE
New sex files

### DIFF
--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -105,7 +105,7 @@ def main(
     sex_df = pd.concat([tob_sex_df, bioheart_sex_df], axis=0)
 
     # # option 2: combined file
-    # at the moment this is not up to date, but ideally this would be ideal to run instead
+    # at the moment this is not up to date, but ideally this would be what we'd run instead
     # sample_qc_ht_path = dataset_path(f'large_cohort/{vds_version}/sample_qc.ht')
     # sample_qc_ht = hl.read_table(sample_qc_ht_path)
     # # convert to pandas


### PR DESCRIPTION
Instead of using temporary files we previously created ad hoc to obtain sex information, use most up-to-date info from the Sample QC part from the large cohort pipeline (note: these are Hail Table files, rather than CSV/TSV).

At the moment, the more reliably up-to-date files are cohort specific (@katiedelange is this right?), but eventually I anticipate a single `tenk10k` file so I have added that syntax (commented out) for the future.

Using these files which are in `main-analysis` also allows us to run with `standard` permission, see discussion in this PR: https://github.com/populationgenomics/saige-tenk10k/pull/143