### PR TITLE
add single variant results rare test

### DIFF
--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -392,6 +392,13 @@ def main(
                 # unique output path for this set-based test
                 set_output_path = output_path(set_key, 'analysis')
 
+                step2_job.declare_resource_group(
+                    output={
+                        'set': '{root}',
+                        'singleAssoc.txt': '{root}.singleAssoc.txt',
+                    }
+                )
+
                 # if the output exists, do nothing
                 if to_path(set_output_path).exists():
                     continue
@@ -400,7 +407,7 @@ def main(
                 build_run_set_based_test_command(
                     job=step2_job,
                     set_key=set_key,
-                    set_output_path=set_output_path,
+                    set_output_path=set_output_path.output,
                     vcf_group=vcf_group,
                     chrom=(chromosome[3:]),
                     group_file=group_path,


### PR DESCRIPTION
So SAIGE-QTL rare variant test actually allows for running single-variant tests as well as set-based tests, when setting the `is_single_in_groupTest` flag to True ([which we are doing](https://github.com/populationgenomics/saige-tenk10k/blob/main/saige_assoc_test.toml#L51)).
The file gets saved to the same location where the set-based test results are written to, and has the same name except with an additional `.singleAssoc.txt` at the end (see [docs](https://weizhou0.github.io/SAIGE-QTL-doc/docs/set_step2.html)).

I've tried to modify this script to mimic something similar we do for the null_job output ([lines](https://github.com/populationgenomics/saige-tenk10k/blob/main/saige_assoc_set_test.py#L211-L216)) but I am really not confident 😅 