### PR TITLE
start adding to writeout file writing

### DIFF
--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -366,6 +366,10 @@ def main(
     vre_plink_path = f'{vre_files_prefix}/vre_plink_2000_variants'
     writeout_dict['vre_plink_files_prefix_used'] = vre_plink_path
 
+    writeout_dict['cis_window_files_path_used'] = cis_window_files_path
+    cis_window_size = get_config()['saige']['cis_window_size']
+    writeout_dict['cis_window_size_used'] = cis_window_size
+
     for chromosome in chromosomes:
 
         # genotype vcf files are one per chromosome
@@ -388,8 +392,6 @@ def main(
 
         # cis window files are split by gene but organised by chromosome also
         cis_window_files_path_chrom = f'{cis_window_files_path}/{chromosome}'
-
-        cis_window_size = get_config()['saige']['cis_window_size']
 
         for celltype in celltypes:
             # extract gene list based on genes for which we have pheno cov files

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -359,18 +359,16 @@ def main(
 
     vre_plink_path = f'{vre_files_prefix}/vre_plink_2000_variants'
 
-    cis_window_size = get_config()['saige']['cis_window_size']
-
     # populate all the important params into a file for long-term reference
     writeout_dict: dict = {
         'ar_guid': try_get_ar_guid() or 'UNKNOWN',
-        'chromosomes': chromosomes,
-        'celltypes': celltypes,
-        'drop_genes': drop_genes,
         'vre_plink_files_prefix_used': vre_plink_path,
         'pheno_cov_files_path_used': pheno_cov_files_path,
         'cis_window_files_path_used': cis_window_files_path,
-        'cis_window_size_used': cis_window_size,
+        'saige_fit_null_params': get_config()['saige'],
+        'saige_single_variant_test_params': get_config()['saige.sv_test'],
+        'saige_fit_null_job_specs': get_config()['saige.job_specs.fit_null'],
+        'saige_single_variant_test_job_specs': get_config()['saige.job_specs.sv_test'],
         'runtime_config': getenv('CPG_CONFIG_PATH'),
     }
 

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -316,7 +316,9 @@ def create_second_job(vcf_path: str) -> hb.batch.job.Job:
 @click.option(
     '--vre-files-prefix', default=dataset_path('saige-qtl/input_files/genotypes')
 )
-@click.option('--writeout-file-prefix', default=dataset_path('saige-qtl'))
+@click.option(
+    '--writeout-file-prefix', default=dataset_path('saige-qtl', category='analysis')
+)
 @click.option('--test-str', is_flag=True, help='Test with STR VCFs')
 @click.option('--jobs-per-vm', type=int, default=25)
 @click.command()

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -368,6 +368,7 @@ def main(
         'celltypes': celltypes,
         'drop_genes': drop_genes,
         'vre_plink_files_prefix_used': vre_plink_path,
+        'pheno_cov_files_path_used': pheno_cov_files_path,
         'cis_window_files_path_used': cis_window_files_path,
         'cis_window_size_used': cis_window_size,
         'runtime_config': getenv('CPG_CONFIG_PATH'),

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -363,6 +363,7 @@ def main(
     # populate all the important params into a file for long-term reference
     writeout_dict: dict = {
         'ar_guid': try_get_ar_guid() or 'UNKNOWN',
+        'results_output_path': output_path(''),
         'vre_plink_files_prefix_used': vre_plink_path,
         'pheno_cov_files_path_used': pheno_cov_files_path,
         'cis_window_files_path_used': cis_window_files_path,

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -358,6 +358,7 @@ def main(
     celltype_jobs: dict[str, list] = dict()
 
     vre_plink_path = f'{vre_files_prefix}/vre_plink_2000_variants'
+    cis_window_size = get_config()['saige']['cis_window_size']
 
     # populate all the important params into a file for long-term reference
     writeout_dict: dict = {

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -350,7 +350,7 @@ def main(
     # define writeout file by type of pipeline and date and time
     date_and_time = datetime.today().strftime('%Y-%m-%d_%H:%M:%S')
     writeout_file = (
-        f'{writeout_file_prefix}/saige_qtl_common_variant_pipeline_{date_and_time}.csv'
+        f'{writeout_file_prefix}/saige_qtl_common_variant_pipeline_{date_and_time}.json'
     )
 
     # pull principal args from config

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -364,6 +364,7 @@ def main(
     writeout_dict['drop_genes'] = ",".join(str(dg) for dg in drop_genes)
 
     vre_plink_path = f'{vre_files_prefix}/vre_plink_2000_variants'
+    writeout_dict['vre_plink_files_prefix_used'] = vre_plink_path
 
     for chromosome in chromosomes:
 
@@ -376,7 +377,7 @@ def main(
             vcf_file_path = (
                 f'{genotype_files_prefix}/{chromosome}_common_variants.vcf.bgz'
             )
-
+        writeout_dict[f'{chromosome}_vcf_file_used'] = vcf_file_path
         single_var_test_job = create_second_job(vcf_file_path)
         jobs_in_vm = 0
 

--- a/saige_assoc.py
+++ b/saige_assoc.py
@@ -349,7 +349,9 @@ def main(
 
     # define writeout file by type of pipeline and date and time
     date_and_time = datetime.today().strftime('%Y-%m-%d_%H:%M:%S')
-    writeout_file = f'{writeout_file_prefix}/saige_qtl_cv_pipeline_{date_and_time}.csv'
+    writeout_file = (
+        f'{writeout_file_prefix}/saige_qtl_common_variant_pipeline_{date_and_time}.csv'
+    )
 
     # pull principal args from config
     chromosomes: list[str] = get_config()['saige']['chromosomes']

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -287,7 +287,9 @@ def create_a_2b_job() -> hb.batch.job.Job:
 @click.option(
     '--vre-files-prefix', default=dataset_path('saige-qtl/input_files/genotypes')
 )
-@click.option('--writeout-file-prefix', default=dataset_path('saige-qtl'))
+@click.option(
+    '--writeout-file-prefix', default=dataset_path('saige-qtl', category='analysis')
+)
 @click.option('--ngenes-to-test', default='all')
 @click.option('--group-file-specs', default='')
 @click.option('--jobs-per-vm', default=10, type=int)

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -43,7 +43,6 @@ import logging
 from datetime import datetime
 from os import getenv
 
-from google.cloud import storage
 import hailtop.batch as hb
 
 from cpg_utils import to_path

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -324,7 +324,7 @@ def main(
     # define writeout file by type of pipeline and date and time
     date_and_time = datetime.today().strftime('%Y-%m-%d_%H:%M:%S')
     writeout_file = (
-        f'{writeout_file_prefix}/saige_qtl_rare_variant_pipeline_{date_and_time}.csv'
+        f'{writeout_file_prefix}/saige_qtl_rare_variant_pipeline_{date_and_time}.json'
     )
 
     # pull principal args from config


### PR DESCRIPTION
The idea here is that every time I run this pipeline I write out a text file detailing all the flags / files / params I ran this with, to aid reproducibility.

Specifically, included in the file are:
- paths to the input files (genotype files, phenotype + covariate files, cis window files)
- flags + params from config file (e.g. chromosomes and cell types considered, and then all [SAIGE-QTL](https://github.com/weizhou0/qtl) flags)
- `ar_guid`: analysis runner unique ID
- `runtime_config` is the combination of all the default analysis-runner content (references, images, etc.), plus any config files added using `--config`
- the filename will include date and time on when this is run, and the prefix can be provided as an argument to the script, so may include additional info on the "type" of run, e.g. "run with permuted ID to assess calibration", "test run on only one chrom", and maybe in the future "conditional analysis" or other!