### PR TITLE
Maf not alt freq

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -320,7 +320,7 @@ def main(
         mt = hl.variant_qc(mt)
 
         # minor allele count (MAC) > {vre_mac_threshold}
-        vre_mt = mt.filter_rows(mt.variant_qc.AC[1] > vre_mac_threshold)
+        vre_mt = mt.filter_rows(hl.min(mt.variant_qc.AC) > vre_mac_threshold)
 
         if (n_ac_vars := vre_mt.count_rows()) == 0:
             raise ValueError('No variants left, exiting!')

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -261,7 +261,7 @@ def main(
 
             if not cv_vcf_existence_outcome:
                 # common variants only
-                cv_mt = mt.filter_rows(mt.variant_qc.AF[1] >= cv_maf_threshold)
+                cv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) >= cv_maf_threshold)
 
                 # remove fields not in the VCF
                 cv_mt = cv_mt.drop('gvcf_info')
@@ -271,7 +271,7 @@ def main(
 
             if not rv_vcf_existence_outcome:
                 # common variants only
-                rv_mt = mt.filter_rows(mt.variant_qc.AF[1] < rv_maf_threshold)
+                rv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) < rv_maf_threshold)
 
                 # remove fields not in the VCF
                 rv_mt = rv_mt.drop('gvcf_info')

--- a/helper/variant_counter.py
+++ b/helper/variant_counter.py
@@ -69,12 +69,12 @@ def count_variants(
     mt = hl.variant_qc(mt)
 
     # select common, low-frequency and rare variants
-    cv_mt = mt.filter_rows(mt.variant_qc.AF[1] >= cv_maf_threshold)
+    cv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) >= cv_maf_threshold)
     lf_mt = mt.filter_rows(
-        (mt.variant_qc.AF[1] >= rv_maf_threshold)
-        & (mt.variant_qc.AF[1] < cv_maf_threshold)
+        (hl.min(mt.variant_qc.AF) >= rv_maf_threshold)
+        & (hl.min(mt.variant_qc.AF) < cv_maf_threshold)
     )
-    rv_mt = mt.filter_rows(mt.variant_qc.AF[1] < rv_maf_threshold)
+    rv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) < rv_maf_threshold)
 
     # count up both donors and variants
     n_common_vars, n_donors = cv_mt.count()


### PR DESCRIPTION
As noted here: https://ibg.colorado.edu/cdrom2021/Day08-veerapan/2021_IBG_Hail/Materials/outputPDF/01-Hail-common-variant-analysis.pdf the frequencies in AF are with respect to a reference (i.e. they are reference / alternative), whereas we are interested in the minor allele within our population. So addressing this in the code.
