### PR TITLE
drop NAs prior to permuting donors

### DIFF
--- a/get_sample_covariates.py
+++ b/get_sample_covariates.py
@@ -171,6 +171,8 @@ def main(
 
     # combine sex, age and geno PC info
     combined_sex_age_pcs = pd.concat([sex_df, age_df, pcs_df], axis=1)
+    # drop NAs
+    combined_sex_age_pcs.dropna(inplace=True)
 
     # add permuted sample ids for calibration analysis
     samples = combined_sex_age_pcs.index


### PR DESCRIPTION
The next line permutes donor ids for calibration purposes, but the donor ids newly assigned may have missing values, and may be not present in the genotype files for association, so worth dropping rows with NA values at this stage.

Note: we have a strategy in place to fill in NAs for sex and age if needed, but not for PCs?