### PR TITLE
Use splitlines() instead of readlines() to prevent trailing newlines

### DIFF
--- a/subset_vds.py
+++ b/subset_vds.py
@@ -124,7 +124,7 @@ def parse_intervals(intervals: str) -> list[str]:
     interval_list: list[str] = []
     if to_path(intervals).exists():
         with open(to_path(intervals), "rt") as interval_file:
-            interval_list = interval_file.readlines()
+            interval_list = interval_file.read().splitlines()
     else:
         interval_list = intervals.split(",")
     return interval_list
@@ -188,7 +188,7 @@ def parse_samples_list(samples: str) -> list[str]:
     sample_list: list[str] = []
     if to_path(samples).exists():
         with open(to_path(samples), "rt") as samples_file:
-            sample_list = samples_file.readlines()
+            sample_list = samples_file.read().splitlines()
     else:
         sample_list = samples.split(",")
     return sample_list


### PR DESCRIPTION
Using readlines() keeps a trailing '\n' at the end of each ID/intervl. Replacing this with .read().splitlines() fixes this, and should be tractable as we are unlikely to have extremely large files being inputted here.