### PR TITLE
Vds not vcf

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -84,7 +84,7 @@ def make_group_file(
         f'{allele[0]}:{allele[1]}' for allele in ds_result.alleles.collect()
     ]
     variants = [
-        f'{variants_chrom_pos[i]}:{variants_alleles[i]}'.replace('chr','')
+        f'{variants_chrom_pos[i]}:{variants_alleles[i]}'.replace('chr', '')
         for i in range(len(variants_chrom_pos))
     ]
 

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -61,7 +61,7 @@ def make_group_file(
     num_chrom = gene_df.columns.values[0]
     window_start = gene_df.columns.values[1]
     window_end = gene_df.columns.values[2]
-    gene_interval = f'{num_chrom}:{window_start}-{window_end}'
+    gene_interval = f'chr{num_chrom}:{window_start}-{window_end}'
     # extract variants within interval
     vds = hl.vds.read_vds(vds_path)
     chrom_vds = hl.vds.filter_chromosomes(vds, keep=chrom)

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -49,7 +49,6 @@ def make_group_file(
     """
     import math
 
-    # from hail import filter_intervals, import_vcf, parse_locus_interval
     from hail import filter_intervals, parse_locus_interval
     import pandas as pd
     from cpg_utils.hail_batch import init_batch

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -139,7 +139,8 @@ def main(
     chromosomes: str,
     cis_window_files_path: str,
     group_files_path: str,
-    vcf_path: str,
+    # vcf_path: str,
+    vds_path,
     cis_window: int,
     gamma: str,
     ngenes_to_test: str,
@@ -206,6 +207,7 @@ def main(
                 gene_group_job.call(
                     make_group_file,
                     # vcf_path_chrom=vcf_path_chrom,
+                    vds_path=vds_path,
                     gene=gene,
                     chrom=chrom,
                     cis_window_files_path=cis_window_files_path,

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -35,7 +35,6 @@ from cpg_utils.hail_batch import get_batch, init_batch
 
 
 def make_group_file(
-    # vcf_path_chrom: str,
     vds_path: str,
     gene: str,
     chrom: str,
@@ -65,14 +64,9 @@ def make_group_file(
     window_end = gene_df.columns.values[2]
     gene_interval = f'{num_chrom}:{window_start}-{window_end}'
     # extract variants within interval
-    # ds = import_vcf(vcf_path_chrom, reference_genome=genome_reference)
     vds = hl.vds.read_vds(vds_path)
     chrom_vds = hl.vds.filter_chromosomes(vds, keep=chrom)
     chrom_mt = hl.vds.to_dense_mt(chrom_vds)
-    # ds_result = filter_intervals(
-    #     ds,
-    #     [parse_locus_interval(gene_interval, reference_genome=genome_reference)],
-    # )
     ds_result = filter_intervals(
         chrom_mt,
         [parse_locus_interval(gene_interval, reference_genome=genome_reference)],
@@ -139,7 +133,6 @@ def main(
     chromosomes: str,
     cis_window_files_path: str,
     group_files_path: str,
-    # vcf_path: str,
     vds_path,
     cis_window: int,
     gamma: str,
@@ -187,9 +180,6 @@ def main(
         ]
         logging.info(f'I found these genes: {", ".join(genes)}')
 
-        # # load rare variant vcf file for specific chromosome
-        # vcf_path_chrom = f'{vcf_path}/{chrom}_rare_variants.vcf.bgz'
-
         for gene in genes:
             print(f'gene: {gene}')
             if gamma != 'none':
@@ -206,7 +196,6 @@ def main(
                 )
                 gene_group_job.call(
                     make_group_file,
-                    # vcf_path_chrom=vcf_path_chrom,
                     vds_path=vds_path,
                     gene=gene,
                     chrom=chrom,

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,16 +1,16 @@
 [saige]
 # principal arguments
 celltypes = ['CD4_TCM']
-chromosomes = ['chr21']
+chromosomes = ['chr2']
 drop_genes =[]
 
 # secondary arguments
-max_parallel_jobs = 350
+max_parallel_jobs = 50
 cis_window_size = 100000
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
 [saige.build_fit_null]
-covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,bioheart'
+covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,BioHEART'
 sampleCovarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5'
 sampleIDColinphenoFile = 'individual'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,11 +1,11 @@
 [saige]
 # principal arguments
 celltypes = ['CD4_TCM']
-chromosomes = ['chr2']
+chromosomes = ['chr21']
 drop_genes =[]
 
 # secondary arguments
-max_parallel_jobs = 50
+max_parallel_jobs = 350
 cis_window_size = 100000
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "


### PR DESCRIPTION
Ok so this was confusing, some of my make group file jobs were failing ([e.g.](https://batch.hail.populationgenomics.org.au/batches/494002/jobs/2385)) because they were not finding the locus in a chromosome, even though these were extracted by the same files.

I realised that the issue was what has been an annoying confusion here: we are using `GRCh38` as our genome reference, and Hail by default uses the `chr` nomenclature for chromosomes (so, e.g. `chr1`).
SAIGE-QTL however uses numerical only chromosomes (so, e.g. `1`) which is why we remove 'chr' from all genotype files ([bims](https://github.com/populationgenomics/saige-tenk10k/blob/main/get_genotype_vcf.py#L87) and [vcfs](https://github.com/populationgenomics/saige-tenk10k/blob/main/get_genotype_vcf.py#L76)).
Confusingly, this is also what Hail uses by default for `GRCh37` so here when opening the VCF file (with the removed `chr`) I got confused and opened it thinking it was reference 37.

In this PR I switch from using the chromosome specific VCF files to just re-opening the VDS so I make sure the reference is 38, add `chr` to the intervals before parsing and then I manually remove it gain just before saving to file, to please SAIGE-QTL.

I also noticed a typo in the formatting of the `bioheart` cohort as a covariate in the toml file so changing that also.