### PR TITLE
Revert "Vds not vcf"

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -27,7 +27,6 @@ analysis-runner \
 import click
 import logging
 
-import hail as hl
 import hailtop.batch.job as hb_job
 
 from cpg_utils import to_path
@@ -35,7 +34,7 @@ from cpg_utils.hail_batch import get_batch, init_batch
 
 
 def make_group_file(
-    vds_path: str,
+    vcf_path_chrom: str,
     gene: str,
     chrom: str,
     cis_window_files_path: str,
@@ -49,7 +48,7 @@ def make_group_file(
     """
     import math
 
-    from hail import filter_intervals, parse_locus_interval
+    from hail import filter_intervals, import_vcf, parse_locus_interval
     import pandas as pd
     from cpg_utils.hail_batch import init_batch
 
@@ -61,13 +60,11 @@ def make_group_file(
     num_chrom = gene_df.columns.values[0]
     window_start = gene_df.columns.values[1]
     window_end = gene_df.columns.values[2]
-    gene_interval = f'chr{num_chrom}:{window_start}-{window_end}'
+    gene_interval = f'{num_chrom}:{window_start}-{window_end}'
     # extract variants within interval
-    vds = hl.vds.read_vds(vds_path)
-    chrom_vds = hl.vds.filter_chromosomes(vds, keep=chrom)
-    chrom_mt = hl.vds.to_dense_mt(chrom_vds)
+    ds = import_vcf(vcf_path_chrom, reference_genome=genome_reference)
     ds_result = filter_intervals(
-        chrom_mt,
+        ds,
         [parse_locus_interval(gene_interval, reference_genome=genome_reference)],
     )
     variants_chrom_pos = [
@@ -77,7 +74,7 @@ def make_group_file(
         f'{allele[0]}:{allele[1]}' for allele in ds_result.alleles.collect()
     ]
     variants = [
-        f'{variants_chrom_pos[i]}:{variants_alleles[i]}'.replace('chr', '')
+        f'{variants_chrom_pos[i]}:{variants_alleles[i]}'
         for i in range(len(variants_chrom_pos))
     ]
 
@@ -113,11 +110,11 @@ def make_group_file(
 @click.option('--chromosomes', help=' chr1,chr22 ')
 @click.option('--cis-window-files-path')
 @click.option('--group-files-path')
-@click.option('--vds-path')
+@click.option('--vcf-path')
 @click.option('--cis-window', default=100000)
 @click.option('--gamma', default='1e-5')
 @click.option('--ngenes-to-test', default='all')
-@click.option('--genome-reference', default='GRCh38')
+@click.option('--genome-reference', default='GRCh37')
 @click.option(
     '--concurrent-job-cap',
     type=int,
@@ -132,7 +129,7 @@ def main(
     chromosomes: str,
     cis_window_files_path: str,
     group_files_path: str,
-    vds_path,
+    vcf_path: str,
     cis_window: int,
     gamma: str,
     ngenes_to_test: str,
@@ -179,6 +176,9 @@ def main(
         ]
         logging.info(f'I found these genes: {", ".join(genes)}')
 
+        # load rare variant vcf file for specific chromosome
+        vcf_path_chrom = f'{vcf_path}/{chrom}_rare_variants.vcf.bgz'
+
         for gene in genes:
             print(f'gene: {gene}')
             if gamma != 'none':
@@ -195,7 +195,7 @@ def main(
                 )
                 gene_group_job.call(
                     make_group_file,
-                    vds_path=vds_path,
+                    vcf_path_chrom=vcf_path_chrom,
                     gene=gene,
                     chrom=chrom,
                     cis_window_files_path=cis_window_files_path,

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -10,7 +10,7 @@ cis_window_size = 100000
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
 [saige.build_fit_null]
-covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,BioHEART'
+covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,bioheart'
 sampleCovarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5'
 sampleIDColinphenoFile = 'individual'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal


### PR DESCRIPTION
Reverts populationgenomics/saige-tenk10k#184

Nope sorry that's dumb, I do need to subset to rare variants only 🤦‍♀️ and the VDS will just have all variants in the cohort.. 
Arghh, do you know of a way I can just update the chromosome names in Hail so I can deal with it without changing the genome reference? 

EDIT: I think SAIGE-QTL has an option of defining the *max* MAF I want to test, so could leave them in here and change the config maybe? Looking into this now 👀 

Yep, I can! Will send a new PR changing [this line](https://github.com/populationgenomics/saige-tenk10k/blob/main/saige_assoc_test.toml#L47) to `0.01` which is [the current default](https://github.com/populationgenomics/saige-tenk10k/blob/main/get_genotype_vcf.py#L126) and add a note in the README to flag that both these need to be changed together.