### PR TITLE
decrease max maf in group

### DIFF
--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -44,9 +44,9 @@ markers_per_chunk = 10000
 SPAcutoff = 10000
 [saige.set_test]
 vcfField = 'GT'
-maxMAF_in_groupTest = 0.1
+maxMAF_in_groupTest = 0.01
 minMAF_in_groupTest_Exclude = 0
-annotation_in_groupTest = 'null,test'
+annotation_in_groupTest = 'null'
 MACCutoff_to_CollapseUltraRare = 1
 is_single_in_groupTest = 'TRUE'
 is_equal_weight_in_groupTest = 'TRUE'

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,6 +1,6 @@
 [saige]
 # principal arguments
-celltypes = ['CD4_TCM']
+celltypes = ['B_naive']
 chromosomes = ['chr21']
 drop_genes =[]
 


### PR DESCRIPTION
As noted in https://github.com/populationgenomics/saige-tenk10k/pull/185, the recent PR (https://github.com/populationgenomics/saige-tenk10k/pull/184) changes the variants included in a group file, which is passed to the `saige_assoc_set_test.py` and defines the variants to be tested for a given gene.

Here, we want to only test rare variants which is why we originally took in the `rare variant` VCF file as an input and subsetted that to the gene interval of interest. With the recent change, we're taking the full VDS as input, which includes all variants instead (both common and rare). However, to ensure we are only testing rare variants, we can change the appropriate flag when running SAIGE-QTL itself, which I am doing here.

Also deleting a leftover `test` annotation which is not a real annotation.