### PR TITLE
add job delay

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -26,6 +26,7 @@ analysis-runner \
 
 import click
 import logging
+from random import randint
 
 import hail as hl
 import hailtop.batch.job as hb_job
@@ -128,6 +129,12 @@ def make_group_file(
         'risk jobs that are stuck (which are expensive)'
     ),
 )
+@click.option(
+    '--max-delay',
+    type=int,
+    default=3000,
+    help='delay starting the jobs as they all access the same VDS which causes Hail issues',
+)
 def main(
     chromosomes: str,
     cis_window_files_path: str,
@@ -138,6 +145,7 @@ def main(
     ngenes_to_test: str,
     genome_reference: str,
     concurrent_job_cap: int,
+    max_delay: int,
 ):
     """
     Make group file for rare variant pipeline
@@ -193,6 +201,7 @@ def main(
                 gene_group_job = get_batch().new_python_job(
                     name=f'gene make group file: {gene}'
                 )
+                gene_group_job.command(f'sleep {randint(0, max_delay)}')
                 gene_group_job.call(
                     make_group_file,
                     vds_path=vds_path,

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,18 +1,17 @@
 [saige]
 # principal arguments
-celltypes = ['B_naive']
+celltypes = ['CD4_TCM']
 chromosomes = ['chr21']
-drop_genes =[]
-
+drop_genes =['ENSG00000278996','ENSG00000241837']
 # secondary arguments
-max_parallel_jobs = 350
+max_parallel_jobs = 50
 cis_window_size = 100000
 # these args are applied directly to step1_fitNULLGLMM_qtl.R
 # as "--{key}={value} "
 [saige.build_fit_null]
 covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,BioHEART'
 sampleCovarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5'
-sampleIDColinphenoFile = 'individual'
+sampleIDColinphenoFile = 'sample_perm0'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal
 traitType = 'count'
 
@@ -30,7 +29,7 @@ skipModelFitting = 'FALSE'
 # tolerance for convergence
 tol = 0.00001
 # max iterations (increase if it fails to converge)
-maxiterPCG = 5000
+maxiterPCG = 500
 IsOverwriteVarianceRatioFile = 'TRUE'
 [saige.sv_test]
 vcfField = 'GT'
@@ -63,3 +62,4 @@ storage = '25G'
 [saige.job_specs.set_test]
 cpu = 1
 storage = '30G'
+memory = "10G"

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -2,7 +2,7 @@
 # principal arguments
 celltypes = ['CD4_TCM']
 chromosomes = ['chr21']
-drop_genes =['ENSG00000278996','ENSG00000241837']
+drop_genes =[]
 # secondary arguments
 max_parallel_jobs = 50
 cis_window_size = 100000
@@ -11,7 +11,7 @@ cis_window_size = 100000
 [saige.build_fit_null]
 covarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5,harmony_PC1,harmony_PC2,harmony_PC3,harmony_PC4,harmony_PC5,BioHEART'
 sampleCovarColList = 'sex,age,geno_PC1,geno_PC2,geno_PC3,geno_PC4,geno_PC5'
-sampleIDColinphenoFile = 'sample_perm0'
+sampleIDColinphenoFile = 'individual'
 # Poisson, count_nb = Negative Binomial, quantitative = Normal
 traitType = 'count'
 


### PR DESCRIPTION
Adding a delay at the start of each job (max 5 minutes assuming the unit is seconds) to avoid too many jobs trying to accessing the same VDS file at once.

Slack thread: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1728950510597129.

p.s. some config params are also changed here: these are some sensible ones I have been using so I am comfortable having them in `main`, but happy to change them back if we want this PR to only address the delay stuff.  