### PR TITLE
save chrom rare mts

### DIFF
--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -200,6 +200,22 @@ def main(
 
             mt = hl.variant_qc(mt)
 
+            if not rv_vcf_existence_outcome or rv_mt_existence_outcome:
+                # rare variants only
+                rv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) < rv_maf_threshold)
+
+                if not rv_mt_existence_outcome:
+                    # save chrom + rare variant mt for group file script
+                    rv_mt.write(rv_mt_path)
+                    rv_mt = hl.read_matrix_table(rv_mt_path)
+
+                if not rv_vcf_existence_outcome:
+                    # remove fields not in the VCF
+                    rv_mt = rv_mt.drop('gvcf_info')
+
+                    # export to vcf rare variants only
+                    export_vcf(rv_mt, rv_vcf_path)
+
             if not cv_vcf_existence_outcome:
                 # common variants only
                 cv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) >= cv_maf_threshold)
@@ -209,21 +225,6 @@ def main(
 
                 # export to vcf common variants only
                 export_vcf(cv_mt, cv_vcf_path)
-
-            if not rv_vcf_existence_outcome or rv_mt_existence_outcome:
-                # rare variants only
-                rv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) < rv_maf_threshold)
-
-                if not rv_vcf_existence_outcome:
-                    # remove fields not in the VCF
-                    rv_mt = rv_mt.drop('gvcf_info')
-
-                    # export to vcf rare variants only
-                    export_vcf(rv_mt, rv_vcf_path)
-
-                if not rv_mt_existence_outcome:
-                    # save chrom + rare variant mt for group file script
-                    rv_mt.write(rv_mt_path)
 
         # check existence of index file (CV) separately
         cv_index_file_existence_outcome = can_reuse(f'{cv_vcf_path}.csi')

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -171,7 +171,11 @@ def main(
         rv_mt_existence_outcome = can_reuse(rv_mt_path)
         logging.info(f'Does {rv_mt_path} exist? {rv_mt_existence_outcome}')
 
-        if not cv_vcf_existence_outcome or not rv_vcf_existence_outcome or not rv_mt_existence_outcome:
+        if (
+            not cv_vcf_existence_outcome
+            or not rv_vcf_existence_outcome
+            or not rv_mt_existence_outcome
+        ):
             # consider only relevant chromosome
             chrom_vds = hl.vds.filter_chromosomes(vds, keep=chromosome)
 

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -210,19 +210,20 @@ def main(
                 # export to vcf common variants only
                 export_vcf(cv_mt, cv_vcf_path)
 
-            if not rv_vcf_existence_outcome:
-                # common variants only
+            if not rv_vcf_existence_outcome or rv_mt_existence_outcome:
+                # rare variants only
                 rv_mt = mt.filter_rows(hl.min(mt.variant_qc.AF) < rv_maf_threshold)
 
-                # remove fields not in the VCF
-                rv_mt = rv_mt.drop('gvcf_info')
+                if not rv_vcf_existence_outcome:
+                    # remove fields not in the VCF
+                    rv_mt = rv_mt.drop('gvcf_info')
 
-                # export to vcf rare variants only
-                export_vcf(rv_mt, rv_vcf_path)
+                    # export to vcf rare variants only
+                    export_vcf(rv_mt, rv_vcf_path)
 
-            if not rv_mt_existence_outcome:
-                # save chrom + rare variant mt for group file script
-                rv_mt.write(rv_mt_path)
+                if not rv_mt_existence_outcome:
+                    # save chrom + rare variant mt for group file script
+                    rv_mt.write(rv_mt_path)
 
         # check existence of index file (CV) separately
         cv_index_file_existence_outcome = can_reuse(f'{cv_vcf_path}.csi')

--- a/get_genotype_vcf.py
+++ b/get_genotype_vcf.py
@@ -167,7 +167,11 @@ def main(
         rv_vcf_existence_outcome = can_reuse(rv_vcf_path)
         logging.info(f'Does {rv_vcf_path} exist? {rv_vcf_existence_outcome}')
 
-        if not cv_vcf_existence_outcome or not rv_vcf_existence_outcome:
+        rv_mt_path = output_path(f'vds-{vds_name}/{chromosome}_rare_variants.mt')
+        rv_mt_existence_outcome = can_reuse(rv_mt_path)
+        logging.info(f'Does {rv_mt_path} exist? {rv_mt_existence_outcome}')
+
+        if not cv_vcf_existence_outcome or not rv_vcf_existence_outcome or not rv_mt_existence_outcome:
             # consider only relevant chromosome
             chrom_vds = hl.vds.filter_chromosomes(vds, keep=chromosome)
 
@@ -211,6 +215,10 @@ def main(
 
                 # export to vcf rare variants only
                 export_vcf(rv_mt, rv_vcf_path)
+
+            if not rv_mt_existence_outcome:
+                # save chrom + rare variant mt for group file script
+                rv_mt.write(rv_mt_path)
 
         # check existence of index file (CV) separately
         cv_index_file_existence_outcome = can_reuse(f'{cv_vcf_path}.csi')

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -68,7 +68,7 @@ def make_group_file(
     window_end = gene_df.columns.values[2]
     gene_interval = f'chr{num_chrom}:{window_start}-{window_end}'
     # extract variants within interval
-    chrom_mt_filename = f'{mt_path}/{chrom}_rare_variants.mt'
+    chrom_mt_filename = dataset_path(f'{mt_path}/{chrom}_rare_variants.mt')
     chrom_mt = hl.read_matrix_table(chrom_mt_filename)
     ds_result = filter_intervals(
         chrom_mt,
@@ -178,7 +178,7 @@ def main(
             new_job.depends_on(all_jobs[-concurrent_job_cap])
         all_jobs.append(new_job)
 
-    mt_path = dataset_path(f'vds-{vds_name}')
+    mt_path = f'vds-{vds_name}'
 
     # loop over chromosomes
     for chrom in chromosomes.split(','):


### PR DESCRIPTION
Rather than having a separate script as in https://github.com/populationgenomics/saige-tenk10k/pull/192 just save the MT here, which also 
* subsets to rare variants only, which is what I want (group files are only needed for the rare variant test)
* removes related individuals prior to running variant QC

Slack thread for context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1728950510597129

Easy solution to essentially reverting to the change prior to this PR https://github.com/populationgenomics/saige-tenk10k/pull/184 but avoiding the issue with the `chr` notation because the renaming only happens on the VCF file, and this saves the chrom + rare variant MT in parallel to exporting to VCF, prior to the renaming / indexing