### PR TITLE
Group file script without collecting over the distributed object

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -136,8 +136,8 @@ def make_group_file(
         chrom_mt = chrom_mt.key_rows_by(chrom_mt.var).select_rows('gene').rows()
         categories_data = {'gene': [gene, gene, gene], 'category': ['var', 'anno']}
 
-    chrom_mt.export(group_file.replace('.tsv', '_tmp.tsv'))
-    chrom_df = pd.read_csv(group_file.replace('.tsv', '_tmp.tsv'), sep='\t')
+    chrom_mt.export(str(group_file).replace('.tsv', '_tmp.tsv'))
+    chrom_df = pd.read_csv(str(group_file).replace('.tsv', '_tmp.tsv'), sep='\t')
     chrom_df['anno'] = 'null'
     if gamma != 'none':
         # annos before weights

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -12,6 +12,18 @@ SAIGE-QTL association pipeline.
 
 To run:
 
+In main:
+
+analysis-runner \
+    --description "make variant group input files" \
+    --dataset "bioheart" \
+    --access-level "standard" \
+    --output-dir "saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/" \
+    python3 make_group_file.py --chromosomes chr21 \
+        --cis-window-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/cis_window_files/ \
+        --group-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/group_files_mt/ \
+        --chrom-mt-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/genotypes/vds-tenk10k1-0_qc_pass --max-delay=30
+
 In test:
 
 analysis-runner \

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -81,9 +81,10 @@ def make_group_file(
     chrom_mt = chrom_mt.annotate_rows(
         variant_string=hl.delimit(
             [
-                chrom_mt.chrom.replace('chr', ''),
+                chrom_mt.locus.contig.replace('chr', ''),
                 hl.str(chrom_mt.locus.position),
-                *chrom_mt.alleles,
+                chrom_mt.alleles[0],
+                chrom_mt.alleles[1],
             ],
             ':',
         ),

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -12,15 +12,18 @@ SAIGE-QTL association pipeline.
 
 To run:
 
+In test:
+
 analysis-runner \
-    --dataset "bioheart" \
-    --description "make variant group input files" \
-    --access-level "standard" \
-    --output-dir "saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/" \
-    python3 make_group_file.py --chromosomes chr21 \
-        --cis-window-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/cis_window_files/ \
-        --group-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/group_files_mt/ \
-        --chrom-mt-files-path=gs://cpg-bioheart-main/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/input_files/genotypes/vds-tenk10k1-0_qc_pass
+   --description "make variant group input files" \
+   --dataset "bioheart" \
+   --access-level "test" \
+   --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/" \
+   python3 make_group_file.py --chromosomes chr21 \
+       --cis-window-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/cis_window_files/ \
+       --group-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/group_files_mt/ \
+       --chrom-mt-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/genotypes/vds-tenk10k1-0_subset --max-delay=10
+
 """
 
 import click

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -115,12 +115,28 @@ def make_group_file(
             .select_rows('var', 'gene', 'weight:dTSS')
             .rows()
         )
+        categories_data = {
+            'gene': [gene, gene, gene],
+            'category': ['var', 'anno', 'weight:dTSS'],
+        }
 
     else:
         # we don't annotate weights/distances
         chrom_mt = chrom_mt.key_rows_by(chrom_mt.var).select_rows('var', 'gene').rows()
+        categories_data = {'gene': [gene, gene, gene], 'category': ['var', 'anno']}
 
     chrom_mt.export(group_file.replace('.tsv', '_tmp.tsv'))
+    chrom_df = pd.read_csv(group_file.replace('.tsv', '_tmp.tsv'), sep='\t')
+    chrom_df['anno'] = 'null'
+    if gamma != 'none':
+        # annos before weights
+        chrom_df = chrom_df[['var', 'anno', 'weight:dTSS']]
+    vals_df = chrom_df.T
+    vals_df['category'] = vals_df.index
+    categories_df = pd.DataFrame(categories_data)
+    group_vals_df = pd.merge(categories_df, vals_df, on='category')
+    with group_file.open('w') as gdf:
+        group_vals_df.to_csv(gdf, index=False, header=False, sep=' ')
 
 
 @click.command()

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -67,51 +67,47 @@ def make_group_file(
     window_start = gene_df.columns.values[1]
     window_end = gene_df.columns.values[2]
     gene_interval = f'chr{num_chrom}:{window_start}-{window_end}'
-    # extract variants within interval
+    # extract variants within interval - ideally drop this read & densify (see #193)
     vds = hl.vds.read_vds(vds_path)
     chrom_vds = hl.vds.filter_chromosomes(vds, keep=chrom)
     chrom_mt = hl.vds.to_dense_mt(chrom_vds)
-    ds_result = filter_intervals(
+    chrom_mt = filter_intervals(
         chrom_mt,
         [parse_locus_interval(gene_interval, reference_genome=genome_reference)],
     )
-    variants_chrom_pos = [
-        f'{loc.contig}:{loc.position}' for loc in ds_result.locus.collect()
-    ]
-    variants_alleles = [
-        f'{allele[0]}:{allele[1]}' for allele in ds_result.alleles.collect()
-    ]
-    variants = [
-        f'{variants_chrom_pos[i]}:{variants_alleles[i]}'.replace('chr', '')
-        for i in range(len(variants_chrom_pos))
-    ]
+
+    # strip the chr from chromosome, annotate as a new field
+    # create a new text field with both alleles
+    chrom_mt = chrom_mt.annotate_rows(
+        variant_string=hl.delimit([chrom_mt.chrom.replace('chr', ''), hl.str(chrom_mt.locus.position), chrom_mt.alleles], ':'),
+        gene=gene
+    )
 
     if gamma != 'none':
+
         gene_tss = int(window_start) + cis_window
-        distances = [int(var.split(":")[1]) - gene_tss for var in variants]
+
+        # annotate distances
+        chrom_mt = chrom_mt.annotate_rows(distance=hl.abs(chrom_mt.locus.position - gene_tss))
+
         # get weight for genetic variants based on
         # the distance of that variant from the gene
         # Following the approach used by the APEX authors
         # doi: https://doi.org/10.1101/2020.12.18.423490
-        weights = [math.exp(-float(gamma) * abs(d)) for d in distances]
-        group_df = pd.DataFrame(
-            {
-                'gene': [gene, gene, gene],
-                'category': ['var', 'anno', 'weight:dTSS'],
-            }
-        )
-        vals_df = pd.DataFrame(
-            {'var': variants, 'anno': 'null', 'weight:dTSS': weights}
-        ).T
-    else:
-        group_df = pd.DataFrame({'gene': [gene, gene], 'category': ['var', 'anno']})
-        vals_df = pd.DataFrame({'var': variants, 'anno': 'null'}).T
-    vals_df['category'] = vals_df.index
-    # combine
-    group_vals_df = pd.merge(group_df, vals_df, on='category')
+        chrom_mt = chrom_mt.annotate_rows(**{'weight:dTSS': math.exp(-float(gamma) * chrom_mt.distance)})
 
-    with group_file.open('w') as gdf:
-        group_vals_df.to_csv(gdf, index=False, header=False, sep=' ')
+        # re-key by variant string instead of locus/alleles
+        # select the columns we want (dropping the rest)
+        # keep only the rows
+        chrom_mt = chrom_mt.key_rows_by(chrom_mt).select_rows(
+            'variant_string', 'gene', 'distance', 'weight:dTSS'
+        ).rows()
+
+    else:
+        # we don't annotate weights/distances
+        chrom_mt = chrom_mt.key_rows_by(chrom_mt).select_rows('variant_string', 'gene').rows()
+
+    chrom_mt.write(group_file)
 
 
 @click.command()

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -32,9 +32,9 @@ analysis-runner \
    --access-level "test" \
    --output-dir "saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/" \
    python3 make_group_file.py --chromosomes chr21 \
-       --cis-window-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/cis_window_files/ \
-       --group-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/group_files_mt/ \
-       --chrom-mt-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/genotypes/vds-tenk10k1-0_subset --max-delay=10
+       --cis-window-files-path gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/cis_window_files/ \
+       --group-files-path gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/group_files_mt/ \
+       --chrom-mt-files-path gs://cpg-bioheart-test/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/genotypes/vds-tenk10k1-0_subset --max-delay=10
 
 """
 

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -125,7 +125,7 @@ def make_group_file(
         # keep only the rows
         chrom_mt = (
             chrom_mt.key_rows_by(chrom_mt.var)
-            .select_rows('var', 'gene', 'weight:dTSS')
+            .select_rows('gene', 'weight:dTSS')
             .rows()
         )
         categories_data = {
@@ -135,7 +135,7 @@ def make_group_file(
 
     else:
         # we don't annotate weights/distances
-        chrom_mt = chrom_mt.key_rows_by(chrom_mt.var).select_rows('var', 'gene').rows()
+        chrom_mt = chrom_mt.key_rows_by(chrom_mt.var).select_rows('gene').rows()
         categories_data = {'gene': [gene, gene, gene], 'category': ['var', 'anno']}
 
     chrom_mt.export(group_file.replace('.tsv', '_tmp.tsv'))

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -34,7 +34,7 @@ analysis-runner \
    python3 make_group_file.py --chromosomes chr21 \
        --cis-window-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/cis_window_files/ \
        --group-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/group_files_mt/ \
-       --chrom-mt-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/genotypes/vds-tenk10k1-0_subset --max-delay=10
+       --chrom-mt-files-path gs://cpg-bioheart-main/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/input_files/genotypes/vds-tenk10k1-0_subset --max-delay=10
 
 """
 

--- a/make_group_file.py
+++ b/make_group_file.py
@@ -124,9 +124,7 @@ def make_group_file(
         # select the columns we want (dropping the rest)
         # keep only the rows
         chrom_mt = (
-            chrom_mt.key_rows_by(chrom_mt.var)
-            .select_rows('gene', 'weight:dTSS')
-            .rows()
+            chrom_mt.key_rows_by(chrom_mt.var).select_rows('gene', 'weight:dTSS').rows()
         )
         categories_data = {
             'gene': [gene, gene, gene],

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,8 +1,8 @@
 [saige]
 # principal arguments
 celltypes = ['CD4_TCM']
-chromosomes = ['chr21']
-drop_genes =[]
+chromosomes = ['chr20']
+drop_genes =['ENSG00000125744','ENSG00000196421','ENSG00000291100']
 # secondary arguments
 max_parallel_jobs = 50
 cis_window_size = 100000


### PR DESCRIPTION
Might be worth giving this a run in test and seeing if the syntax works out

The group_file script collects all loci and variants in the MT, then operates on them. This is a hugely inefficient operation, as it localises the data.

This is an attempt to do the same thing inside the mt:

1. annotate a new value into the MT 'chr:pos:ref:alt' (with "chr" prefix removed)
2. calculate distances and re-annotate into the MT
3. calculate the weights and re-annotate into the MT
4. export a table to TSV containing either `'variant_string', 'gene', 'distance', 'weight:dTSS'` or `'variant_string', 'gene'`

This would need some editing/transposition to exactly match the format you were generating previously, but it should scale much better than the fully-collected version