### PR TITLE
better syntax

### DIFF
--- a/coloc/coloc_runner.py
+++ b/coloc/coloc_runner.py
@@ -205,8 +205,8 @@ def main(
 
                 # extract the coordinates for the cis-window (gene +/- 100kB)
                 gene_table = var_table[var_table['gene_ids'] == gene]
-                start = int(gene_table['start'].astype(int).iloc[0]) - cis_window_size
-                end = int(gene_table['end'].astype(int).iloc[0]) + cis_window_size
+                start = int(gene_table['start'].iloc[0]) - cis_window_size
+                end = int(gene_table['end'].iloc[0]) + cis_window_size
                 chrom = gene_table['chr'].iloc[0]
                 hg38_map_chr = hg38_map[hg38_map['chromosome'] == (chrom)]
                 hg38_map_chr_start = hg38_map_chr[hg38_map_chr['position'] >= start]

--- a/coloc/coloc_runner.py
+++ b/coloc/coloc_runner.py
@@ -205,8 +205,8 @@ def main(
 
                 # extract the coordinates for the cis-window (gene +/- 100kB)
                 gene_table = var_table[var_table['gene_ids'] == gene]
-                start = int(gene_table['start'].astype(int)) - cis_window_size
-                end = int(gene_table['end'].astype(int)) + cis_window_size
+                start = int(gene_table['start'].astype(int).iloc[0]) - cis_window_size
+                end = int(gene_table['end'].astype(int).iloc[0]) + cis_window_size
                 chrom = gene_table['chr'].iloc[0]
                 hg38_map_chr = hg38_map[hg38_map['chromosome'] == (chrom)]
                 hg38_map_chr_start = hg38_map_chr[hg38_map_chr['position'] >= start]


### PR DESCRIPTION
Not entirely sure why the [test run](https://batch.hail.populationgenomics.org.au/batches/531164/jobs/1) didn't throw an error and the [main](https://batch.hail.populationgenomics.org.au/batches/531182/jobs/1) one did?

This change clears the warning in my notebook so hopefully a fix?