### PR TITLE
Split get_anndata into a separate batch per gene

### DIFF
--- a/get_anndata.py
+++ b/get_anndata.py
@@ -42,7 +42,7 @@ import subprocess
 
 from cpg_utils import to_path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import get_batch, init_batch, output_path
+from cpg_utils.hail_batch import get_batch, init_batch, output_path, reset_batch
 
 
 def filter_lowly_expressed_genes(expression_adata, min_pct=1) -> sc.AnnData:
@@ -298,6 +298,17 @@ def main(
             cmd = ["gsutil", "cp", tmp_adata_name, tmp_path]
             subprocess.run(cmd, check=True)
 
+            # create a new batch for genes in this cell type
+            # reset the list of jobs
+            all_jobs: List[hb_job.Job] = []
+            # reset the batch
+            reset_batch()
+            # set this up with the default (scanpy) python image
+            get_batch(
+               default_python_image=get_config()['images']['scanpy'],
+               name='prepare all gene files',
+            )
+
             # start up some jobs for each gene
             for gene in expression_adata.var.index:
                 # change hyphens to underscore for R usage
@@ -348,8 +359,7 @@ def main(
                     )
                     manage_concurrency(gene_cis_job)
                     logging.info(f'cis window job for {gene} scheduled')
-
-    get_batch().run(wait=False)
+            get_batch().run(wait=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Current issue: 

e.g. https://batch.hail.populationgenomics.org.au/batches/533125/jobs/1

The driver job runs across all celltypes/genes/chromosomes in a loop, pushing all the required jobs into a single batch.

The batch only runs once this full cycle is complete.

In the linked example (a relatively small chromosome) this means the driver has spent 3 hours before releasing any jobs, time that could have been spent processing.

This change proposes using the reset_batch() mechanic to create a new hail Batch for each Gene. We clear the list of jobs used when setting dependencies (so we don't accidentally depend on a job from a different batch), and once we find all jobs for a gene, we fire them off. There are no dependencies between genes, so this should be safe.

The result here should be a driver job running continuously, and periodically starting a new Hail Batch, each containing all jobs for a (chrom, celltype), spanning all genes.

This might not be the exact right syntax/indentation, I wrote it in the github interface 😬 
It might also spawn a wild number of separate batches (depending on how many genes are in the workflow). The mechanic to skip a job if the result already exists is still present, so this should be a process you can run repeatedly, and it will detect only the new jobs that need to run.