### PR TITLE
use round

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -77,7 +77,7 @@ def make_group_file(
     print(f'gene file: {gene_file}')
     gene_df = pd.read_csv(gene_file, sep='\t')
     num_chrom = gene_df.columns.values[0]
-    window_start = gene_df.columns.values[1]
+    window_start = round(float(gene_df.columns.values[1]))
     window_end = gene_df.columns.values[2]
     gene_interval = f'chr{num_chrom}:{window_start}-{window_end}'
     # extract variants within interval

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,8 +1,8 @@
 [saige]
 # principal arguments
 celltypes = ['CD4_TCM']
-chromosomes = ['chr21']
-drop_genes =[]
+chromosomes = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9','chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17','chr18','chr19','chr20','chr21','chr22']
+drop_genes = ['ENSG00000291100','ENSG00000278996','ENSG00000215386','ENSG00000291100','ENSG00000196421','ENSG00000171858','ENSG00000211679','ENSG00000108298','ENSG00000121101','ENSG00000161970','ENSG00000265681','ENSG00000125744','ENSG00000233927','ENSG00000170889','ENSG00000167618','ENSG00000142541','ENSG00000137959','ENSG00000290122','ENSG00000289474','ENSG00000109321','ENSG00000161055','ENSG00000228716','ENSG00000248874','ENSG00000124762','ENSG00000196376','ENSG00000204388','ENSG00000204389','ENSG00000146918','ENSG00000229618','ENSG00000254349','ENSG00000167114','ENSG00000185532','ENSG00000248905','ENSG00000259345','ENSG00000197943','ENSG00000259692']
 # secondary arguments
 max_parallel_jobs = 50
 cis_window_size = 100000
@@ -29,7 +29,7 @@ skipModelFitting = 'FALSE'
 # tolerance for convergence
 tol = 0.00001
 # max iterations (increase if it fails to converge)
-maxiterPCG = 500
+maxiterPCG = 5000
 IsOverwriteVarianceRatioFile = 'TRUE'
 [saige.sv_test]
 vcfField = 'GT'
@@ -55,11 +55,11 @@ markers_per_chunk = 10000
 SPAcutoff = 10000
 [saige.job_specs.fit_null]
 storage = "0G"
-memory = "4Gi"
+memory = "25G"
 [saige.job_specs.sv_test]
 cpu = 1
 storage = '25G'
 [saige.job_specs.set_test]
 cpu = 1
 storage = '30G'
-memory = "15G"
+memory = "80G"


### PR DESCRIPTION
Because the cis window file read here is a single line, it gets read as the header of the data frame when opened in.
In the unlikely case where two values are identical (it happens [here](https://batch.hail.populationgenomics.org.au/batches/577759/jobs/95) when opening `cpg-tenk10k-main/saige-qtl/tenk10k-genome-2-3-eur/input_files/241210/cis_window_files/chr1/ENSG00000238009_100000bp.tsv` where both `chr` and `window_start` are 1), to avoid duplicated column names the second `1` gets turned into `1.1` which is then confusing when restricting an MT to a genomic range, as 1.1 is not a valid position. A bit hacky but "rounding" the value to the closest int fixes it here (in all cases `.1` would get rounded down).

screenshot of my notebook to illustrate the issue

<img width="1057" alt="Screenshot 2024-12-23 at 4 47 31 PM" src="https://github.com/user-attachments/assets/7dfc3b97-74f9-49da-a13b-96737d5a76cb" />
