### PR TITLE
Update and add multi pheno runner

### DIFF
--- a/coloc/coloc_runner.py
+++ b/coloc/coloc_runner.py
@@ -34,7 +34,9 @@ from cpg_utils import to_path
 from cpg_utils.hail_batch import get_batch, image_path, output_path
 
 
-def coloc_runner(gwas, eqtl_file_path, celltype, coloc_results_file):
+def coloc_runner(
+    gwas, eqtl_file_path, celltype, coloc_results_file, common_maf_threshold
+):
     import rpy2.robjects as ro
     from rpy2.robjects import pandas2ri
 
@@ -66,6 +68,8 @@ def coloc_runner(gwas, eqtl_file_path, celltype, coloc_results_file):
     # while I figure out if it's easy to extract sdY, give N and MAF instead
     # https://chr1swallace.github.io/coloc/articles/a02_data.html#what-if-i-dont-have-sdy
     eqtl['MAF'] = eqtl['AF_Allele2'].apply(lambda af: min(af, (1 - af)))
+    # subset to only results for variants above chosen MAF
+    eqtl = eqtl[eqtl['MAF'] > common_maf_threshold]
     gene = eqtl_file_path.split('/')[-1].replace(f'{celltype}_', '').replace('_cis', '')
     with (ro.default_converter + pandas2ri.converter).context():
         eqtl_r = ro.conversion.get_conversion().py2rpy(eqtl)
@@ -134,6 +138,10 @@ def coloc_runner(gwas, eqtl_file_path, celltype, coloc_results_file):
 @click.option('--cis-window-size', help='Cis window size used', default=100000)
 @click.option('--fdr-threshold', help='FDR threshold', default=0.05)
 @click.option(
+    '--gwas-significance-threshold', help='GWAS significance threshold', default=5e-8
+)
+@click.option('--common-maf-threshold', help='common MAF threshold', default=0.01)
+@click.option(
     '--max-parallel-jobs', help='Maximum number of parallel jobs to run', default=500
 )
 @click.option('--job-cpu', help='Number of CPUs to use for each job', default=0.25)
@@ -147,6 +155,8 @@ def main(
     gene_info_file: str,
     cis_window_size: int,
     fdr_threshold: float,
+    gwas_significance_threshold: float,
+    common_maf_threshold: float,
     max_parallel_jobs: int,
     job_cpu: float,
 ):
@@ -218,8 +228,11 @@ def main(
                         f'No SNP GWAS data for {gene} in the cis-window: skipping....'
                     )
                     continue
-                # check if the p-value column contains at least one value which is <=5e-8:
-                if hg38_map_chr_start_end['p_value'].min() > 5e-8:
+                # check if the p-value column contains at least one value which is genome-wide significant:
+                if (
+                    hg38_map_chr_start_end['p_value'].min()
+                    > gwas_significance_threshold
+                ):
                     print(
                         f'No significant SNP GWAS data for {gene}in the cis-window: skipping....'
                     )
@@ -238,6 +251,7 @@ def main(
                     eqtl_results_file,
                     celltype,
                     coloc_results_file,
+                    common_maf_threshold,
                 )
                 manage_concurrency_for_job(coloc_job)
 

--- a/coloc/coloc_runner.py
+++ b/coloc/coloc_runner.py
@@ -115,12 +115,12 @@ def coloc_runner(gwas, eqtl_file_path, celltype, coloc_results_file):
 @click.option(
     '--egenes-files-path',
     help='Path to the gene-level summary files',
-    default='gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/output_files/summary_stats',
+    default='gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/input_files/241210/summary_stats',
 )
 @click.option(
     '--snp-cis-dir',
     help='Path to the directory containing the SNP cis results',
-    default='gs://cpg-bioheart-main-analysis/saige-qtl/bioheart_n787_and_tob_n960/241008_ashg/output_files',
+    default='gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/output_files/241210',
 )
 @click.option(
     '--snp-gwas-file',

--- a/coloc/coloc_runner.py
+++ b/coloc/coloc_runner.py
@@ -9,11 +9,11 @@ Assumes that the SNP GWAS data has been pre-processed with the following columns
 
 1) Identify eGenes using FDR < fdr_threshold (default: 0.05)
 2) Extract the SNP GWAS data for the cis-window (gene +/- window; default: 100kB)
-3) Run coloc for each eGene (if the SNP GWAS data has at least one variant with pval <5e-8)
+3) Run coloc for each eGene (if the SNP GWAS data has at least one significant variant; default pval <5e-8)
 4) Write the results to a TSV file
 
 analysis-runner --dataset "bioheart" \
-    --description "Run coloc for eGenes identified by SAIGE-QTL analysis" \
+    --description "Run coloc for disease traits and eGenes identified by SAIGE-QTL analysis" \
     --access-level "full" \
     --memory='8G' \
     --image "australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:d4922e3062565ff160ac2ed62dcdf2fba576b75a-hail-8f6797b033d2e102575c40166cf0c977e91f834e" \

--- a/coloc/coloc_runner.py
+++ b/coloc/coloc_runner.py
@@ -119,7 +119,7 @@ def coloc_runner(
 @click.option(
     '--egenes-files-path',
     help='Path to the gene-level summary files',
-    default='gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/input_files/241210/summary_stats',
+    default='gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/output_files/241210/summary_stats',
 )
 @click.option(
     '--snp-cis-dir',

--- a/coloc/coloc_runner.py
+++ b/coloc/coloc_runner.py
@@ -129,7 +129,7 @@ def coloc_runner(gwas, eqtl_file_path, celltype, coloc_results_file):
 )
 @click.option(
     '--gene-info-file',
-    default='gs://cpg-bioheart-test/saige-qtl/300-libraries/combined_anndata_obs_vars/300_libraries_concatenated_harmony_filtered_vars_all_genes.csv',
+    default='gs://cpg-tenk10k-test/saige-qtl/300libraries_n1925_adata_raw_var.csv',
 )
 @click.option('--cis-window-size', help='Cis window size used', default=100000)
 @click.option('--fdr-threshold', help='FDR threshold', default=0.05)

--- a/coloc/multi_pheno_coloc_runner.sh
+++ b/coloc/multi_pheno_coloc_runner.sh
@@ -53,7 +53,7 @@ for celltype in "${celltype_array[@]}"; do
         analysis-runner --dataset "tenk10k" \
         --description "Run coloc for eGenes identified by SAIGE-QTL" \
         --access-level "full" \
-        --memory='16G' \
+        --memory='32G' \
         --image "australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:d4922e3062565ff160ac2ed62dcdf2fba576b75a-hail-8f6797b033d2e102575c40166cf0c977e91f834e" \
         --output-dir "saige-qtl/tenk10k-genome-2-3-eur/output_files/241210" \
         coloc/coloc_runner.py \

--- a/coloc/multi_pheno_coloc_runner.sh
+++ b/coloc/multi_pheno_coloc_runner.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Define the cell types as a comma-separated string
+celltypes='ASDC,B_intermediate,B_memory,B_naive,CD14_Mono,CD16_Mono,CD4_CTL,CD4_Naive,CD4_Proliferating,CD4_TCM,CD4_TEM,CD8_Naive,CD8_Proliferating,CD8_TCM,CD8_TEM,cDC1,cDC2,dnT,gdT,HSPC,ILC,MAIT,NK,NK_CD56bright,NK_Proliferating,pDC,Plasmablast,Treg'
+
+# Convert the cell types into an array
+IFS=',' read -ra celltype_array <<< "$celltypes"
+
+# Define phenotypes and file paths as parallel arrays
+pheno_names=(
+    "alzheimer_GCST90027158"
+    "breastca_GCST004988"
+    "colorectalca_GCST90129505"
+    "covid_GCST011071"
+    "ibd_liu2023"
+    "NHL_GCST90011819"
+    "lungca_GCST004748"
+    "lymphoma_GCST90018878"
+    "parkinson_GCST009325"
+    "prostateca_GCST90274713"
+    "ra_GCST90132223"
+    "sle_GCST003156"
+    "myeloproliferative_GCST90000032"
+    "lymphocytic_leukemia_GCST90011814"
+    "nephrotic_GCST90258619"
+    "kiryluk_IgAN"
+)
+
+pheno_files=(
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST90027158.h_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST004988.h_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/colorectalca_GCST90129505_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST011071_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/ibd_EAS_EUR_SiKJEF_meta_IBD.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/NHL_GCST90011819_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST004748.h_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST90018878.h_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST009325.h_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST90274713.h_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/GCST90132223_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/bentham_2015_26502338_sle_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/myeloproliferative_GCST90000032_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/lymphocytic_leukemia_GCST90011814_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/nephrotic_GCST90258619_parsed.tsv"
+    "gs://cpg-bioheart-test/str/gwas_catalog/gcst/gcst-gwas-catalogs/Kiryluk_IgAN_parsed.tsv"
+)
+
+# Loop through each cell type and phenotype
+for celltype in "${celltype_array[@]}"; do
+    for i in "${!pheno_names[@]}"; do
+        pheno="${pheno_names[$i]}"
+        filepath="${pheno_files[$i]}"
+        analysis-runner --dataset "tenk10k" \
+        --description "Run coloc for eGenes identified by SAIGE-QTL" \
+        --access-level "full" \
+        --memory='16G' \
+        --image "australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:d4922e3062565ff160ac2ed62dcdf2fba576b75a-hail-8f6797b033d2e102575c40166cf0c977e91f834e" \
+        --output-dir "saige-qtl/tenk10k-genome-2-3-eur/input_files/241210" \
+        coloc/coloc_runner.py \
+        --egenes-files-path=gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/output_files/241210/summary_stats \
+        --snp-cis-dir=gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/output_files/241210 \
+        --snp-gwas-file="$filepath" \
+        --pheno-output-name="$pheno" \
+        --celltypes="$celltype" \
+        --max-parallel-jobs 10000
+    done
+done

--- a/coloc/multi_pheno_coloc_runner.sh
+++ b/coloc/multi_pheno_coloc_runner.sh
@@ -55,7 +55,7 @@ for celltype in "${celltype_array[@]}"; do
         --access-level "full" \
         --memory='16G' \
         --image "australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:d4922e3062565ff160ac2ed62dcdf2fba576b75a-hail-8f6797b033d2e102575c40166cf0c977e91f834e" \
-        --output-dir "saige-qtl/tenk10k-genome-2-3-eur/input_files/241210" \
+        --output-dir "saige-qtl/tenk10k-genome-2-3-eur/output_files/241210" \
         coloc/coloc_runner.py \
         --egenes-files-path=gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/output_files/241210/summary_stats \
         --snp-cis-dir=gs://cpg-tenk10k-main-analysis/saige-qtl/tenk10k-genome-2-3-eur/output_files/241210 \


### PR DESCRIPTION
This PR adds a multi pheno + multi celltype runner, and removes all constants making them adjustable parameters instead:

* MAF threshold (esp relevant as we accidentally ran for variants with MAF<1%)
* GWAS threshold to determine whether to run coloc

It also updates default paths to latest freeze.

Multi pheno runner syntax worked in `test` and ran successfully: 

* [585031](https://batch.hail.populationgenomics.org.au/batches/585031/jobs/1) 
* [585032](https://batch.hail.populationgenomics.org.au/batches/585032/jobs/1) 

files in `cpg-tenk10k-test-analysis/saige-qtl/bioheart_n990_and_tob_n1055/241004_n100/coloc-snp-only/sig_genes_only`
