### PR TITLE
Flexible output paths

### DIFF
--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# pylint: disable=import-error,line-too-long
 
 """
 Hail Batch workflow to perform set-based tests using SAIGE-QTL


### PR DESCRIPTION
Adds flexibility to run Step 2+ in parallel when the workflow is re-run with different folders of group files

This naming convention has not been used until now, so there are a couple of scenarios:

If the group file path is the default in the docstring `.../bioheart_n990_and_tob_n1055/input_files/240920/group_files`, the script will recognise `group_files` and use the group file version `default` as a prefix instead.

If the group file path contains a version, e.g. `.../bioheart_n990_and_tob_n1055/input_files/240920/group_files/V2`, `V2` will be used as the version prefix when writing output files.

This leaves Step 1/null model fitting unaffected, only changing the output paths to step 2, and the path used to detect those step 2 files when generating the summary