### PR TITLE
Clean group file

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -144,6 +144,8 @@ def make_group_file(
 
     chrom_mt.export(str(group_file).replace('.tsv', '_tmp.tsv'))
     chrom_df = pd.read_csv(str(group_file).replace('.tsv', '_tmp.tsv'), sep='\t')
+    chrom_df['POS'] = chrom_df['var'].str.split(':').str[1]
+    chrom_df['POS'] = chrom_df['POS'].astype(int)
 
     # add annotations if required
 


### PR DESCRIPTION
Forgot to copy over a couple of lines from my notebook 🤦‍♀️, getting this error: https://batch.hail.populationgenomics.org.au/batches/633660/jobs/2

It is not a huge deal but at the moment the behaviour is not as expected because multiple files per gene are pulled out but then the format is unexpected for the incorrect window size, so only the right jobs can successfully run and the rest fail immediately, eg https://batch.hail.populationgenomics.org.au/batches/633660

this should avoid the wrong ones being run in the first place.

Also updating / correcting the invocation