### PR TITLE
Groups open chromatin

### DIFF
--- a/make_group_file.py
+++ b/make_group_file.py
@@ -288,6 +288,7 @@ def make_group_file(
     start_idx = rows_matching.index[0]
 
     block_df = final_df.loc[start_idx : start_idx + 2].copy()
+    block_df = block_df.dropna(axis=1)
 
     with group_file.open('w') as gdf:
         block_df.to_csv(gdf, index=False, header=False, sep=' ')

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -455,7 +455,9 @@ def main(
 
                 # step 2 (cis eQTL set-based test)
                 # unique key for this set-based test
-                rare_key = f'{group_annos}/{celltype}/{chromosome}/{celltype}_{gene}_cis_rare'
+                rare_key = (
+                    f'{group_annos}/{celltype}/{chromosome}/{celltype}_{gene}_cis_rare'
+                )
                 # unique output path for this set-based test
                 rare_output_path = output_path(rare_key, 'analysis')
 
@@ -496,7 +498,9 @@ def main(
     # summarise results (per cell type)
     for celltype in celltypes:
         logging.info(f'start summarising results for {celltype}')
-        summary_output_path = f'{group_annos}/summary_stats/{celltype}_all_cis_rv_set_test_results.tsv'
+        summary_output_path = (
+            f'{group_annos}/summary_stats/{celltype}_all_cis_rv_set_test_results.tsv'
+        )
 
         summarise_job = get_batch().new_python_job(
             f'Summarise RV results for {celltype}'

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -396,7 +396,8 @@ def main(
             # do a glob, then pull out all file names as Strings
             files = [
                 file.name
-                for file in to_path(pheno_cov_files_path_ct_chrom).glob(
+                # for file in to_path(pheno_cov_files_path_ct_chrom).glob(
+                for file in to_path(group_files_path_chrom).glob(
                     f'*_{celltype}_pheno_cov.tsv'
                 )
             ]

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -300,7 +300,7 @@ def create_a_2b_job() -> hb.batch.job.Job:
 @click.option('--ngenes-to-test', default='all')
 @click.option('--group-file-specs', default='')
 @click.option('--jobs-per-vm', default=10, type=int)
-@click.option('--group-annos', default='functional')
+# @click.option('--group-annos', default='functional')
 @click.option(
     '--skip-null',
     is_flag=True,
@@ -317,7 +317,7 @@ def main(
     ngenes_to_test: str,
     group_file_specs: str,
     jobs_per_vm: int,
-    group_annos: str,
+    # group_annos: str,
     skip_null: bool,
 ):
     """
@@ -327,9 +327,9 @@ def main(
     # in some runs we may want to skip over genes where null fitting has previously failed
     skipped_genes = []
 
-    group_file_version = to_path(group_files_path).name
-    if group_file_version == 'group_files':
-        group_file_version = 'default'
+    group_annos = to_path(group_files_path).name
+    if group_annos == 'group_files':
+        group_annos = 'default'
 
     batch = get_batch('SAIGE-QTL RV pipeline')
     jobs: list[hb.batch.job.Job] = []
@@ -455,7 +455,7 @@ def main(
 
                 # step 2 (cis eQTL set-based test)
                 # unique key for this set-based test
-                rare_key = f'{group_file_version}_{group_annos}/{celltype}/{chromosome}/{celltype}_{gene}_cis_rare'
+                rare_key = f'{group_annos}/{celltype}/{chromosome}/{celltype}_{gene}_cis_rare'
                 # unique output path for this set-based test
                 rare_output_path = output_path(rare_key, 'analysis')
 
@@ -496,7 +496,7 @@ def main(
     # summarise results (per cell type)
     for celltype in celltypes:
         logging.info(f'start summarising results for {celltype}')
-        summary_output_path = f'{group_file_version}_{group_annos}/summary_stats/{celltype}_all_cis_rv_set_test_results.tsv'
+        summary_output_path = f'{group_annos}/summary_stats/{celltype}_all_cis_rv_set_test_results.tsv'
 
         summarise_job = get_batch().new_python_job(
             f'Summarise RV results for {celltype}'
@@ -508,7 +508,7 @@ def main(
             celltype=celltype,
             # include the group file version and celltype when generating the path to outputs created in this run
             gene_results_path=output_path(
-                f'{group_file_version}_{group_annos}/{celltype}', category='analysis'
+                f'{group_annos}/{celltype}', category='analysis'
             ),
             summary_output_path=summary_output_path,
         )

--- a/saige_assoc_test.toml
+++ b/saige_assoc_test.toml
@@ -1,7 +1,7 @@
 [saige]
 # principal arguments
-celltypes = ['ASDC']
-chromosomes = ['chr11','chr12']
+celltypes = ['CD4_TCM']
+chromosomes = ['chr22']
 drop_genes = ['ENSG00000291100','ENSG00000291011','ENSG00000234464','ENSG00000280164','ENSG00000162989','ENSG00000204802','ENSG00000226007','ENSG00000231212','ENSG00000260691','ENSG00000274893','ENSG00000112562','ENSG00000244694']
 # secondary arguments
 max_parallel_jobs = 50


### PR DESCRIPTION
_very_ annoyingly the current set up of making group files (one per gene) with _all_ of the annotations and then only test for one at the time does not work.

I got lucky the first time (running with `--group-annos='functional'functional`) because *all* genes had at least one variant annotated as functional, but when I tried with e.g. `open_CD4_TCM` I get a bunch of fails because the group file exists and everything so the script starts to run but when subsetting to the relevant there are no variants left for many genes and SAIGE can't run.

If you have any suggestions more than welcome @MattWellie but at the moment I am just creating a bunch more group files, one per anno and then I'll have to add something to the saige_assoc_set_test.py script to skip if the group file required does not exist

EDIT: actually ideally we could at least save multiple files within the make_group_file function if we had multiple `required_anno(s)`, but the file naming would have to move from outside to inside the function I think?