### PR TITLE
Simplify summary process by removing Pandas

### DIFF
--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -262,7 +262,9 @@ def summarise_rv_results(
             if non_empty_files % 100 == 0:
                 print(f'Progress: {non_empty_files} processed, {empty_files} skipped.')
 
-            contents = file.open().readlines()
+            with file.open() as f:
+                contents = f.readlines()
+
             if first_file:
                 first_file = False
                 use_index = 0

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -258,7 +258,7 @@ def summarise_rv_results(
     first_file = True
     with open(local_file, 'w') as handle:
         for file in to_path(gene_results_path).glob(f'*/{celltype}_*_cis_rare.set'):
-            # sub-sample the input files, just so we know we're making progress
+            # subsample the input files, just so we know we're making progress
             if non_empty_files % 100 == 0:
                 print(f'Progress: {non_empty_files} processed, {empty_files} skipped.')
 
@@ -284,7 +284,7 @@ def summarise_rv_results(
     result_all_filename = to_path(
         hail_batch.output_path(summary_output_path, category='analysis')
     )
-    logging.info(f'Write summary results to {result_all_filename}')
+    print(f'Write summary results to {result_all_filename}')
 
     # open the GCP output as a Path, the local file as a simple file handle
     with result_all_filename.open('w') as write_handle, open(

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -250,7 +250,7 @@ def summarise_rv_results(
     from cpg_utils import hail_batch, to_path
 
     # create a new single output file in the Batch TMP Directory (location of VM attached storage)
-    local_file = path.join(getenv('BATCH_TMPDIR'), 'all_set_contents.tsv')
+    local_file = path.join(getenv('BATCH_TMPDIR'), 'all_set_contents.csv')
 
     non_empty_files = 0
     empty_files = 0

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -281,11 +281,15 @@ def summarise_rv_results(
     print(f"✅ Loaded {non_empty_files} files")
     print(f"🚫 Failed to load {empty_files} files")
 
-    result_all_filename = to_path(hail_batch.output_path(summary_output_path, category='analysis'))
+    result_all_filename = to_path(
+        hail_batch.output_path(summary_output_path, category='analysis')
+    )
     logging.info(f'Write summary results to {result_all_filename}')
 
     # open the GCP output as a Path, the local file as a simple file handle
-    with result_all_filename.open('w') as write_handle, open(local_file, 'r') as read_handle:
+    with result_all_filename.open('w') as write_handle, open(
+        local_file, 'r'
+    ) as read_handle:
         data = read_handle.readlines()
         write_handle.writelines(data)
 

--- a/saige_assoc_set_test.py
+++ b/saige_assoc_set_test.py
@@ -241,35 +241,53 @@ def summarise_rv_results(
 ):
     """
     Summarise gene-specific results
+
+    Read all single-test results into a local file, write that local file to GCP in a single operation
     """
-    import logging
-    import pandas as pd
-    from cpg_utils import to_path
-    from cpg_utils.hail_batch import output_path
 
-    existing_rv_assoc_results = [
-        str(file)
-        for file in to_path(gene_results_path).glob(f'*/{celltype}_*_cis_rare.set')
-    ]
-    non_empty_dfs = []
-    empty_files = []
+    from os import path, getenv
 
-    for file_path in existing_rv_assoc_results:
-        try:
-            df = pd.read_csv(file_path, index_col=0, sep='\t')
-            non_empty_dfs.append(df)
-        except Exception as e:
-            print(f"❌ Failed: {file_path}\n   Reason: {e}")
-            empty_files.append((file_path, str(e)))
+    from cpg_utils import hail_batch, to_path
 
-    print(f"\n✅ Loaded {len(non_empty_dfs)} DataFrames")
-    print(f"🚫 Failed to load {len(empty_files)} files")
+    # create a new single output file in the Batch TMP Directory (location of VM attached storage)
+    local_file = path.join(getenv('BATCH_TMPDIR'), 'all_set_contents.tsv')
 
-    results_all_df = pd.concat(non_empty_dfs, ignore_index=False)
-    result_all_filename = to_path(output_path(summary_output_path, category='analysis'))
+    non_empty_files = 0
+    empty_files = 0
+
+    first_file = True
+    with open(local_file, 'w') as handle:
+        for file in to_path(gene_results_path).glob(f'*/{celltype}_*_cis_rare.set'):
+            # sub-sample the input files, just so we know we're making progress
+            if non_empty_files % 100 == 0:
+                print(f'Progress: {non_empty_files} processed, {empty_files} skipped.')
+
+            contents = file.open().readlines()
+            if first_file:
+                first_file = False
+                use_index = 0
+            else:
+                use_index = 1
+
+            # for header-only files, count as empty
+            if len(contents) == 1:
+                empty_files += 1
+                continue
+
+            non_empty_files += 1
+            for line in contents[use_index:]:
+                handle.write(line.replace('\t', ','))
+
+    print(f"✅ Loaded {non_empty_files} files")
+    print(f"🚫 Failed to load {empty_files} files")
+
+    result_all_filename = to_path(hail_batch.output_path(summary_output_path, category='analysis'))
     logging.info(f'Write summary results to {result_all_filename}')
-    with result_all_filename.open('w') as rf:
-        results_all_df.to_csv(rf)
+
+    # open the GCP output as a Path, the local file as a simple file handle
+    with result_all_filename.open('w') as write_handle, open(local_file, 'r') as read_handle:
+        data = read_handle.readlines()
+        write_handle.writelines(data)
 
 
 def create_a_2b_job() -> hb.batch.job.Job:


### PR DESCRIPTION
The current summary process:
- reads each TSV file (1-5) lines into a dataframe
- adds the dataframe to a list
- concatenates all DFs
- writes unified DF as a CSV

for [this batch](https://batch.hail.populationgenomics.org.au/batches/1022845) this is 10754 separate results files all being processed as a dataframe, then requiring a monster merge. This WF has taken a day and a half with no obvious signs of progress :/

This PR suggests a simplification:
- open a local csv file
- read each file in turn
- if it's the first file in the cycle, use all lines (including the header), converting tabs to spaces. Write to the local file
- if it's !first file, only take the data lines from the file, converting tabs to spaces, write to the local file
- once we've finished iterating, open a final output file in GCP, write all data as a single operation

This does all the same things as the previous process, reading each file in turn, converting TSV -> CSV, and writing a new file, but it doesn't need Pandas to do it, and doesn't require a 10000+ DataFrame concatenation. 

Seems to work from local testing 😬 